### PR TITLE
fix modint

### DIFF
--- a/modint/src/lib.rs
+++ b/modint/src/lib.rs
@@ -316,11 +316,7 @@ impl<Mod: Minfo> Mint<Mod> {
             std::mem::swap(&mut x, &mut y);
             std::mem::swap(&mut u, &mut v);
         }
-        if v < Mod::zero() {
-            v + Mod::modulus()
-        } else {
-            v
-        }
+        Self::normalize(v)
     }
 
     fn raw_pow(mut a: Mod::Value, mut b: u64) -> Mod::Value {


### PR DESCRIPTION
ユークリッドの互除法で mod 逆元を求めるところ、最後に出てくるものの範囲がちょっと自信がなく、またちゃんと計算するのもめんどうです。えーい、`normalize` です！