### PR TITLE
add Boolean utils to dbg

### DIFF
--- a/dbg/src/lib.rs
+++ b/dbg/src/lib.rs
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Formatter};
 
 /// `&[<Vec<T>]` を、表形式で列に添字をつけて出力できます。
 #[derive(Clone)]
-pub struct Tabular<'a, T: Debug>(pub &'a [Vec<T>]);
+pub struct Tabular<'a, T: Debug>(pub &'a [T]);
 impl<'a, T: Debug> Debug for Tabular<'a, T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         for i in 0..self.0.len() {

--- a/dbg/src/lib.rs
+++ b/dbg/src/lib.rs
@@ -7,16 +7,43 @@
 
 use std::fmt::{Debug, Formatter};
 
-/// `Vec<Vec<T>>` を、外側の区切りで改行しながら、
-/// 列に添字をつけて出力できます。
+/// `&[<Vec<T>]` を、表形式で列に添字をつけて出力できます。
 #[derive(Clone)]
 pub struct Tabular<'a, T: Debug>(pub &'a [Vec<T>]);
-
 impl<'a, T: Debug> Debug for Tabular<'a, T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         for i in 0..self.0.len() {
             writeln!(f, "{:2} | {:?}", i, &self.0[i])?;
         }
+        Ok(())
+    }
+}
+
+/// `&[<Vec<bool>]` を、`'.','#'` grid 形式で、列に添字をつけて出力できます。
+#[derive(Clone)]
+pub struct BooleanTable<'a>(pub &'a [Vec<bool>]);
+impl<'a> Debug for BooleanTable<'a> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        for i in 0..self.0.len() {
+            writeln!(f, "{:2} | {:?}", i, BooleanSlice(&self.0[i]))?;
+        }
+        Ok(())
+    }
+}
+
+/// `&[bool]` を `'.','#'` の列で出力できます。末尾に改行はありません。
+#[derive(Clone)]
+pub struct BooleanSlice<'a>(pub &'a [bool]);
+impl<'a> Debug for BooleanSlice<'a> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.0
+                .iter()
+                .map(|&b| if b { '#' } else { '.' })
+                .collect::<String>()
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION
# 追加するもの

- `BooleanSlice`: 一次元バージョン
- `BoleanTable`: 二次元バージョン

# ついでに修正です

- `Tabular` が一次元でも使えるようにします。

# Screenshots

[ARC 081 F - Flip and Rectangles](https://atcoder.jp/contests/arc081/tasks/arc081_d)

![Screenshot from 2020-08-08 13-41-08](https://user-images.githubusercontent.com/39984623/89702503-dde27780-d97c-11ea-9955-2f8597101d9a.png)
