### PR TITLE
Feature/add dual segtree

### DIFF
--- a/crates/algolib/dual_segtree/Cargo.toml
+++ b/crates/algolib/dual_segtree/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 type_traits =  { path = "../../utils/type_traits" }
+query_test_2 = { path = "../../utils/query_test_2" }

--- a/crates/algolib/dual_segtree/Cargo.toml
+++ b/crates/algolib/dual_segtree/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dev-dependencies]
+[dependencies]
 type_traits =  { path = "../../utils/type_traits" }
+
+[dev-dependencies]
 query_test_2 = { path = "../../utils/query_test_2" }
+rand = "0.7.3"
+fp = { path = "../../utils/fp" }

--- a/crates/algolib/dual_segtree/Cargo.toml
+++ b/crates/algolib/dual_segtree/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
 type_traits =  { path = "../../utils/type_traits" }
 query_test_2 = { path = "../../utils/query_test_2" }

--- a/crates/algolib/dual_segtree/Cargo.toml
+++ b/crates/algolib/dual_segtree/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dual_segtree"
+version = "0.1.0"
+authors = ["ngtkana <ngtkana@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+type_traits =  { path = "../../utils/type_traits" }

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeBounds;
+use std::ops::{self, Range, RangeBounds};
 use type_traits::{Action, Identity};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -35,17 +35,58 @@ impl<T: Identity> DualSegtree<T> {
                 .collect::<Vec<_>>(),
         }
     }
-    pub fn apply(&mut self, _range: impl RangeBounds<usize>, _x: T) {
-        todo!()
+    pub fn apply(&mut self, range: impl RangeBounds<usize>, x: T) {
+        let Range { mut start, mut end } = open(self.len, range);
+        if start < end {
+            start += self.len;
+            end += self.len;
+            self.thrust(start);
+            self.thrust(end - 1);
+            while start != end {
+                if start % 2 == 1 {
+                    self.table[start].op_from_left(&x);
+                    start += 1;
+                }
+                if end % 2 == 1 {
+                    end -= 1;
+                    self.table[end].op_from_left(&x);
+                }
+                start >>= 1;
+                end >>= 1;
+            }
+        }
     }
     pub fn get(&mut self, mut i: usize) -> &T {
         i += self.len;
         self.thrust(i);
         &self.table[i]
     }
-    fn thrust(&mut self, _i: usize) {
-        todo!()
+    fn thrust(&mut self, i: usize) {
+        let lg = self.lg;
+        (1..=lg)
+            .rev()
+            .map(|p| i >> p)
+            .for_each(|j| self.propagate(j));
     }
+    fn propagate(&mut self, i: usize) {
+        if self.table[i] != T::identity() {
+            let x = std::mem::replace(&mut self.table[i], T::identity());
+            self.table[2 * i].op_from_left(&x);
+            self.table[2 * i + 1].op_from_left(&x);
+        }
+    }
+}
+fn open(len: usize, range: impl RangeBounds<usize>) -> Range<usize> {
+    use ops::Bound::*;
+    (match range.start_bound() {
+        Unbounded => 0,
+        Included(&x) => x,
+        Excluded(&x) => x + 1,
+    })..(match range.end_bound() {
+        Excluded(&x) => x,
+        Included(&x) => x + 1,
+        Unbounded => len,
+    })
 }
 
 #[cfg(test)]
@@ -59,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_add_fp() {
-        use type_traits::{actions::Adj, binary::Add};
+        use type_traits::{actions::Adj, binary::Add, Constant};
         type Node = Add<Fp>;
         type Action = Adj<Node>;
 
@@ -70,13 +111,13 @@ mod tests {
             }
         }
         impl gen::GenValue<Node> for G {
-            fn gen_value<R: Rng>(rng: &mut R) -> Node {
-                Add(Fp::new(rng.gen_range(0, 1)))
+            fn gen_value<R: Rng>(_rng: &mut R) -> Node {
+                Add(Fp::new(0))
             }
         }
         impl gen::GenAction<Action> for G {
             fn gen_action<R: Rng>(rng: &mut R) -> Action {
-                Adj(<G as gen::GenValue<Node>>::gen_value(rng))
+                Adj(Add(Fp::new(rng.gen_range(0, fp::Mod998244353::VALUE))))
             }
         }
 
@@ -84,7 +125,7 @@ mod tests {
         for _ in 0..4 {
             tester.initialize();
             for _ in 0..100 {
-                let command = tester.rng_mut().gen_range(0, 5);
+                let command = tester.rng_mut().gen_range(0, 2);
                 match command {
                     0 => tester.compare_mut::<query::Get<_>>(),
                     1 => tester.mutate::<query::RangeApply<_>>(),

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -240,4 +240,41 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn test_pow_fp() {
+        use type_traits::{actions::Pow, binary::Mul};
+        type Node = Mul<Fp>;
+        type Action = Pow<Mul<Fp>>;
+
+        struct G {}
+        impl gen::GenLen for G {
+            fn gen_len<R: Rng>(rng: &mut R) -> usize {
+                rng.gen_range(1, 20)
+            }
+        }
+        impl gen::GenValue<Node> for G {
+            fn gen_value<R: Rng>(rng: &mut R) -> Node {
+                Mul(Fp::new(rng.gen_range(2, 5)))
+            }
+        }
+        impl gen::GenAction<Action> for G {
+            fn gen_action<R: Rng>(rng: &mut R) -> Action {
+                Pow::new(rng.gen_range(1, 3))
+            }
+        }
+
+        let mut tester = TesterDualSegtreeWith::<Action, G>::new(StdRng::seed_from_u64(42), CONFIG);
+        for _ in 0..4 {
+            tester.initialize();
+            for _ in 0..100 {
+                let command = tester.rng_mut().gen_range(0, 2);
+                match command {
+                    0 => tester.compare_mut::<query::Get<_>>(),
+                    1 => tester.mutate::<query::RangeApply<_>>(),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
 }

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -31,15 +31,12 @@ impl<T: Identity> DualSegtree<T> {
     pub fn apply(&mut self, _range: impl RangeBounds<usize>, _x: T) {
         todo!()
     }
-    pub fn get(&mut self, _i: usize) -> T {
+    pub fn get(&mut self, _i: usize) -> &T {
         todo!()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
+    mod impl_query;
 }

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -65,8 +65,10 @@ impl<T: Action + Identity> DualSegtreeWith<T> {
         self.dual.apply(range, x);
     }
     pub fn get(&mut self, i: usize) -> &T::Space {
-        let x = self.dual.get(i).clone();
-        x.act_mut(&mut self.table[i]);
+        let x = self.dual.take(i);
+        if x != T::identity() {
+            x.act_mut(&mut self.table[i]);
+        }
         &self.table[i]
     }
 }
@@ -117,6 +119,12 @@ impl<T: Identity> DualSegtree<T> {
         i += self.len;
         self.thrust(i);
         &self.table[i]
+    }
+    /// `i` 番目を `1` にして、もともとの値を返します。
+    pub fn take(&mut self, mut i: usize) -> T {
+        i += self.len;
+        self.thrust(i);
+        std::mem::replace(&mut self.table[i], T::identity())
     }
     fn thrust(&mut self, i: usize) {
         let lg = self.lg;

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -1,0 +1,45 @@
+use std::ops::RangeBounds;
+use type_traits::{Action, Identity};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DualSegtreeWith<T: Action> {
+    dual: DualSegtree<T>,
+    table: Vec<T::Space>,
+}
+impl<T: Action> DualSegtreeWith<T> {
+    pub fn from_slice(_src: &[T], _table: &[T::Space]) -> Self {
+        todo!()
+    }
+    pub fn apply(&mut self, _range: impl RangeBounds<usize>, _x: T) {
+        todo!()
+    }
+    pub fn get(&mut self, _i: usize) -> &T::Space {
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DualSegtree<T> {
+    len: usize,
+    lg: u32,
+    lazy: Vec<T>,
+}
+impl<T: Identity> DualSegtree<T> {
+    pub fn from_slice(_src: &[T]) -> Self {
+        todo!()
+    }
+    pub fn apply(&mut self, _range: impl RangeBounds<usize>, _x: T) {
+        todo!()
+    }
+    pub fn get(&mut self, _i: usize) -> T {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -1,15 +1,54 @@
+//! 双対セグメントツリーです。
+//!
+//!
+//! # 抽象データ構造としての双対セグメントツリー
+//!
+//! 半群の要素の列 `a` を管理します。できる操作はこちらです。
+//!
+//! - `build(a)`:
+//!     - 列 `a` に対応する双対セグメントツリーを構築します。
+//!     - 時間計算量 O ( N )
+//!
+//! - `apply_range(l, r, x)`
+//!     - `l` 以上 `r` 未満のすべての項に、（左から）`x` をかけます。
+//!     - 時間計算量 O ( lg ( r - l ) )
+//!
+//! - `get(i)`
+//!     - `i` 番目の要素を取得します。
+//!     - 時間計算量 O ( lg N )
+//!
+//!
+//! # 双対セグメントツリーと作用
+//!
+//! 半群 A が集合 X に作用するとして、集合 X の要素の列 a を管理します。できる操作はこちらです。
+//!
+//! - `build(a)`:
+//!     - （空間側が）列 `a` に対応するデータ構造を構築です。
+//!     - 時間計算量 O ( N )
+//!
+//! - `apply_range(l, r, x)`
+//!     - `l` 以上 `r` 未満のすべての項に、作用素半群 A の要素 `x` を作用します。
+//!     - 時間計算量 O ( lg ( r - l ) )
+//!
+//! - `get(i)`
+//!     - `a` の `i` 番目の要素を取得します。
+//!     - 時間計算量 O ( lg N )
+//!
+//!
 use std::{
     iter,
     ops::{self, Range, RangeBounds},
 };
 use type_traits::{Action, Identity};
 
+/// 双対セグメントツリーを使って作用を管理します。
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualSegtreeWith<T: Action> {
     dual: DualSegtree<T>,
     table: Vec<T::Space>,
 }
 impl<T: Action + Identity> DualSegtreeWith<T> {
+    /// `build(a)` をします。
     pub fn from_slice(table: &[T::Space]) -> Self {
         DualSegtreeWith {
             // TODO: FromIterator を使います。
@@ -32,6 +71,7 @@ impl<T: Action + Identity> DualSegtreeWith<T> {
     }
 }
 
+/// 双対セグメントツリーを実現します。
 #[derive(Debug, Clone, PartialEq)]
 pub struct DualSegtree<T> {
     len: usize,
@@ -39,6 +79,7 @@ pub struct DualSegtree<T> {
     table: Vec<T>,
 }
 impl<T: Identity> DualSegtree<T> {
+    /// `build(a)` をします。
     pub fn from_slice(src: &[T]) -> Self {
         Self {
             len: src.len(),
@@ -49,6 +90,7 @@ impl<T: Identity> DualSegtree<T> {
                 .collect::<Vec<_>>(),
         }
     }
+    /// `apply_range(start, end, x)` をします。
     pub fn apply(&mut self, range: impl RangeBounds<usize>, x: T) {
         let Range { mut start, mut end } = open(self.len, range);
         if start < end {
@@ -70,6 +112,7 @@ impl<T: Identity> DualSegtree<T> {
             }
         }
     }
+    /// `get(i)` をします。
     pub fn get(&mut self, mut i: usize) -> &T {
         i += self.len;
         self.thrust(i);

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -39,4 +39,46 @@ impl<T: Identity> DualSegtree<T> {
 #[cfg(test)]
 mod tests {
     mod impl_query;
+    use query_test_2::{gen, query, Vector, CONFIG};
+    use rand::prelude::*;
+
+    type Fp = fp::F998244353;
+    type Tester<T, G> = query_test_2::Tester<StdRng, Vector<T>, crate::DualSegtree<T>, G>;
+
+    #[test]
+    fn test_add_fp() {
+        use type_traits::{actions::Adj, binary::Add};
+        type Node = Add<Fp>;
+        type Action = Adj<Node>;
+
+        struct G {}
+        impl gen::GenLen for G {
+            fn gen_len<R: Rng>(rng: &mut R) -> usize {
+                rng.gen_range(1, 100)
+            }
+        }
+        impl gen::GenValue<Node> for G {
+            fn gen_value<R: Rng>(rng: &mut R) -> Node {
+                Add(Fp::new(rng.gen_range(0, 1)))
+            }
+        }
+        impl gen::GenAction<Action> for G {
+            fn gen_action<R: Rng>(rng: &mut R) -> Action {
+                Adj(<G as gen::GenValue<Node>>::gen_value(rng))
+            }
+        }
+
+        let mut tester = Tester::<Node, G>::new(StdRng::seed_from_u64(42), CONFIG);
+        for _ in 0..4 {
+            tester.initialize();
+            for _ in 0..100 {
+                let command = tester.rng_mut().gen_range(0, 5);
+                match command {
+                    0 => tester.compare_mut::<query::Get<_>>(),
+                    1 => tester.mutate::<query::RangeApply<_>>(),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
 }

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -1,4 +1,7 @@
-use std::ops::{self, Range, RangeBounds};
+use std::{
+    iter,
+    ops::{self, Range, RangeBounds},
+};
 use type_traits::{Action, Identity};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -6,15 +9,26 @@ pub struct DualSegtreeWith<T: Action> {
     dual: DualSegtree<T>,
     table: Vec<T::Space>,
 }
-impl<T: Action> DualSegtreeWith<T> {
-    pub fn from_slice(_src: &[T], _table: &[T::Space]) -> Self {
-        todo!()
+impl<T: Action + Identity> DualSegtreeWith<T> {
+    pub fn from_slice(table: &[T::Space]) -> Self {
+        DualSegtreeWith {
+            // TODO: FromIterator を使います。
+            dual: DualSegtree::from_slice(
+                iter::repeat_with(T::identity)
+                    .take(table.len())
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            ),
+            table: table.to_vec(),
+        }
     }
-    pub fn apply(&mut self, _range: impl RangeBounds<usize>, _x: T) {
-        todo!()
+    pub fn apply(&mut self, range: impl RangeBounds<usize>, x: T) {
+        self.dual.apply(range, x);
     }
-    pub fn get(&mut self, _i: usize) -> &T::Space {
-        todo!()
+    pub fn get(&mut self, i: usize) -> &T::Space {
+        let x = self.dual.get(i).clone();
+        x.act_mut(&mut self.table[i]);
+        &self.table[i]
     }
 }
 
@@ -148,7 +162,7 @@ mod tests {
         struct G {}
         impl gen::GenLen for G {
             fn gen_len<R: Rng>(rng: &mut R) -> usize {
-                rng.gen_range(1, 100)
+                rng.gen_range(1, 20)
             }
         }
         impl gen::GenValue<Node> for G {

--- a/crates/algolib/dual_segtree/src/lib.rs
+++ b/crates/algolib/dual_segtree/src/lib.rs
@@ -22,16 +22,28 @@ impl<T: Action> DualSegtreeWith<T> {
 pub struct DualSegtree<T> {
     len: usize,
     lg: u32,
-    lazy: Vec<T>,
+    table: Vec<T>,
 }
 impl<T: Identity> DualSegtree<T> {
-    pub fn from_slice(_src: &[T]) -> Self {
-        todo!()
+    pub fn from_slice(src: &[T]) -> Self {
+        Self {
+            len: src.len(),
+            lg: src.len().next_power_of_two().trailing_zeros(),
+            table: std::iter::repeat_with(T::identity)
+                .take(src.len())
+                .chain(src.to_vec())
+                .collect::<Vec<_>>(),
+        }
     }
     pub fn apply(&mut self, _range: impl RangeBounds<usize>, _x: T) {
         todo!()
     }
-    pub fn get(&mut self, _i: usize) -> &T {
+    pub fn get(&mut self, mut i: usize) -> &T {
+        i += self.len;
+        self.thrust(i);
+        &self.table[i]
+    }
+    fn thrust(&mut self, _i: usize) {
         todo!()
     }
 }

--- a/crates/algolib/dual_segtree/src/tests/impl_query.rs
+++ b/crates/algolib/dual_segtree/src/tests/impl_query.rs
@@ -1,7 +1,7 @@
-use crate::DualSegtree;
+use crate::{DualSegtree, DualSegtreeWith};
 use query_test_2::{query, solve, FromBrute, Vector};
 use std::ops::Range;
-use type_traits::{actions::Adj, Identity};
+use type_traits::{actions::Adj, Action, Identity};
 
 impl<T: Identity> FromBrute for DualSegtree<T> {
     type Brute = Vector<T>;
@@ -17,5 +17,22 @@ impl<T: Identity> solve::SolveMut<query::Get<T>> for DualSegtree<T> {
 impl<T: Identity> solve::Mutate<query::RangeApply<Adj<T>>> for DualSegtree<T> {
     fn mutate(&mut self, (range, action): (Range<usize>, Adj<T>)) {
         self.apply(range, action.0)
+    }
+}
+
+impl<T: Action + Identity> FromBrute for DualSegtreeWith<T> {
+    type Brute = Vector<T::Space>;
+    fn from_brute(_brute: &Self::Brute) -> Self {
+        todo!()
+    }
+}
+impl<T: Action + Identity> solve::SolveMut<query::Get<T::Space>> for DualSegtreeWith<T> {
+    fn solve_mut(&mut self, _i: usize) -> T::Space {
+        todo!()
+    }
+}
+impl<T: Action + Identity> solve::Mutate<query::RangeApply<T>> for DualSegtree<T> {
+    fn mutate(&mut self, (_range, _action): (Range<usize>, T)) {
+        todo!()
     }
 }

--- a/crates/algolib/dual_segtree/src/tests/impl_query.rs
+++ b/crates/algolib/dual_segtree/src/tests/impl_query.rs
@@ -31,7 +31,7 @@ impl<T: Action + Identity> solve::SolveMut<query::Get<T::Space>> for DualSegtree
         todo!()
     }
 }
-impl<T: Action + Identity> solve::Mutate<query::RangeApply<T>> for DualSegtree<T> {
+impl<T: Action + Identity> solve::Mutate<query::RangeApply<T>> for DualSegtreeWith<T> {
     fn mutate(&mut self, (_range, _action): (Range<usize>, T)) {
         todo!()
     }

--- a/crates/algolib/dual_segtree/src/tests/impl_query.rs
+++ b/crates/algolib/dual_segtree/src/tests/impl_query.rs
@@ -22,17 +22,17 @@ impl<T: Identity> solve::Mutate<query::RangeApply<Adj<T>>> for DualSegtree<T> {
 
 impl<T: Action + Identity> FromBrute for DualSegtreeWith<T> {
     type Brute = Vector<T::Space>;
-    fn from_brute(_brute: &Self::Brute) -> Self {
-        todo!()
+    fn from_brute(brute: &Self::Brute) -> Self {
+        Self::from_slice(&brute.0)
     }
 }
 impl<T: Action + Identity> solve::SolveMut<query::Get<T::Space>> for DualSegtreeWith<T> {
-    fn solve_mut(&mut self, _i: usize) -> T::Space {
-        todo!()
+    fn solve_mut(&mut self, i: usize) -> T::Space {
+        self.get(i).clone()
     }
 }
 impl<T: Action + Identity> solve::Mutate<query::RangeApply<T>> for DualSegtreeWith<T> {
-    fn mutate(&mut self, (_range, _action): (Range<usize>, T)) {
-        todo!()
+    fn mutate(&mut self, (range, action): (Range<usize>, T)) {
+        self.apply(range, action)
     }
 }

--- a/crates/algolib/dual_segtree/src/tests/impl_query.rs
+++ b/crates/algolib/dual_segtree/src/tests/impl_query.rs
@@ -1,0 +1,21 @@
+use crate::DualSegtree;
+use query_test_2::{query, solve, FromBrute, Vector};
+use std::ops::Range;
+use type_traits::{actions::Adj, Identity};
+
+impl<T: Identity> FromBrute for DualSegtree<T> {
+    type Brute = Vector<T>;
+    fn from_brute(brute: &Self::Brute) -> Self {
+        Self::from_slice(&brute.0)
+    }
+}
+impl<T: Identity> solve::SolveMut<query::Get<T>> for DualSegtree<T> {
+    fn solve_mut(&mut self, i: usize) -> T {
+        self.get(i).clone()
+    }
+}
+impl<T: Identity> solve::Mutate<query::RangeApply<Adj<T>>> for DualSegtree<T> {
+    fn mutate(&mut self, (range, action): (Range<usize>, Adj<T>)) {
+        self.apply(range, action.0)
+    }
+}

--- a/crates/algolib/segtree/src/lib.rs
+++ b/crates/algolib/segtree/src/lib.rs
@@ -199,7 +199,7 @@ impl<T: Identity> Segtree<T> {
         }
         while shift != 0 {
             shift -= 1;
-            start = (orig_start - 1 >> shift) + 1;
+            start = ((orig_start - 1) >> shift) + 1;
             if start % 2 == 1 {
                 let nxt = self.table[start].clone().op(crr.clone());
                 if !pred(&nxt) {

--- a/crates/utils/fp/src/lib.rs
+++ b/crates/utils/fp/src/lib.rs
@@ -120,19 +120,16 @@ where
     Mod::Output: Value,
 {
     /// 整数から構築します。
-    #[inline]
     pub fn new(src: Mod::Output) -> Self {
         Self(Self::normalize(src))
     }
 
     /// 分数から構築します。
-    #[inline]
     pub fn frac(num: Mod::Output, den: Mod::Output) -> Self {
         Self::new(num) / Self::new(den)
     }
 
     /// 中身にキャストします。
-    #[inline]
     pub fn into_inner(self) -> Mod::Output {
         self.0
     }
@@ -178,12 +175,10 @@ where
         ans
     }
 
-    #[inline]
     fn normalize(src: Mod::Output) -> Mod::Output {
         Self::normalize_from_the_top(src % Mod::VALUE)
     }
 
-    #[inline]
     fn normalize_from_the_bottom(src: Mod::Output) -> Mod::Output {
         if Mod::VALUE <= src {
             src - Mod::VALUE
@@ -192,7 +187,6 @@ where
         }
     }
 
-    #[inline]
     fn normalize_from_the_top(src: Mod::Output) -> Mod::Output {
         if src < Mod::Output::zero() {
             src + Mod::VALUE
@@ -206,17 +200,14 @@ impl<Mod: Modable> Zero for Fp<Mod>
 where
     Mod::Output: Value,
 {
-    #[inline]
     fn zero() -> Fp<Mod> {
         Fp::new(Mod::Output::zero())
     }
 }
-
 impl<Mod: Modable> One for Fp<Mod>
 where
     Mod::Output: Value,
 {
-    #[inline]
     fn one() -> Fp<Mod> {
         Fp::new(Mod::Output::one())
     }

--- a/crates/utils/fp/src/lib.rs
+++ b/crates/utils/fp/src/lib.rs
@@ -91,7 +91,7 @@
 //! [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
 pub use aliases::*;
 use std::{cmp, fmt, iter, mem, ops::*};
-use type_traits::*;
+use type_traits::{Constant, NTimes, One, PowN, Ring, Zero};
 
 mod arith;
 
@@ -210,6 +210,23 @@ where
 {
     fn one() -> Fp<Mod> {
         Fp::new(Mod::Output::one())
+    }
+}
+// TODO: Mod の型と u64 の間の変換が厄介です。https://github.com/ngtkana/ac-adapter-rs/issues/53
+impl<Mod: Modable<Output = i64>> NTimes for Fp<Mod>
+where
+    Mod::Output: Value,
+{
+    fn n_times(self, n: u64) -> Fp<Mod> {
+        self * Fp::new(n as i64)
+    }
+}
+impl<Mod: Modable> PowN for Fp<Mod>
+where
+    Mod::Output: Value,
+{
+    fn pow_n(self, n: u64) -> Fp<Mod> {
+        self.pow(n)
     }
 }
 

--- a/crates/utils/query_test_2/src/ds/vector.rs
+++ b/crates/utils/query_test_2/src/ds/vector.rs
@@ -28,10 +28,9 @@ impl<T> Vector<T> {
     }
     fn gen_range<R: Rng, G>(&self, rng: &mut R) -> Range<usize> {
         let mut u = rng.gen_range(0, self.0.len() + 1);
-        let mut v = rng.gen_range(0, self.0.len());
+        let mut v = rng.gen_range(0, self.0.len() + 1);
         if v < u {
             std::mem::swap(&mut u, &mut v);
-            v -= 1;
         }
         u..v
     }

--- a/crates/utils/query_test_2/src/ds/vector.rs
+++ b/crates/utils/query_test_2/src/ds/vector.rs
@@ -76,10 +76,7 @@ mod tests {
         fn mutate(&mut self, (mut i, x): (usize, T)) {
             i += self.len;
             self.table[i] = x;
-            (1..=self.lg)
-                .rev()
-                .map(|p| i >> p)
-                .for_each(|j| self.update(j));
+            (1..=self.lg).map(|p| i >> p).for_each(|j| self.update(j));
         }
     }
     impl<T: Identity> solve::Solve<query::Fold<T>> for Segtree<T> {

--- a/crates/utils/query_test_2/src/ds/vector/impl_gen.rs
+++ b/crates/utils/query_test_2/src/ds/vector/impl_gen.rs
@@ -1,7 +1,7 @@
 use crate::{gen, query, utils, Gen, Vector};
 use rand::Rng;
 use std::ops::Range;
-use type_traits::Identity;
+use type_traits::{Action, Identity};
 
 impl<T, G> Gen<query::Get<T>, G> for Vector<T> {
     fn gen<R: Rng>(&self, rng: &mut R) -> usize {
@@ -38,5 +38,14 @@ where
 {
     fn gen<R: Rng>(&self, rng: &mut R) -> (Range<usize>, U) {
         (self.gen_range::<R, G>(rng), G::gen_folded_key(rng))
+    }
+}
+impl<T, G> Gen<query::RangeApply<T>, G> for Vector<T::Space>
+where
+    T: Action,
+    G: gen::GenAction<T>,
+{
+    fn gen<R: Rng>(&self, rng: &mut R) -> (Range<usize>, T) {
+        (self.gen_range::<R, G>(rng), G::gen_action(rng))
     }
 }

--- a/crates/utils/query_test_2/src/ds/vector/impl_query.rs
+++ b/crates/utils/query_test_2/src/ds/vector/impl_query.rs
@@ -1,6 +1,6 @@
 use crate::{query, solve, utils, Vector};
 use std::ops::Range;
-use type_traits::Identity;
+use type_traits::{Action, Identity};
 
 impl<T> solve::Mutate<query::Set<T>> for Vector<T> {
     fn mutate(&mut self, (i, x): (usize, T)) {
@@ -34,5 +34,12 @@ where
         let fold = |range| P::project(<Self as solve::Solve<query::Fold<T>>>::solve(self, range));
         let Range { start, end } = range;
         i == start || range.contains(&(i - 1)) && (fold(i..end)..fold(i - 1..end)).contains(&value)
+    }
+}
+impl<T: Action> solve::Mutate<query::RangeApply<T>> for Vector<T::Space> {
+    fn mutate(&mut self, (range, action): (Range<usize>, T)) {
+        self.0[range]
+            .iter_mut()
+            .for_each(|x| action.clone().act_mut(x));
     }
 }

--- a/crates/utils/query_test_2/src/gen.rs
+++ b/crates/utils/query_test_2/src/gen.rs
@@ -18,6 +18,12 @@ pub trait GenKey<T> {
     fn gen_key<R: Rng>(rng: &mut R) -> T;
 }
 
+/// 作用素を生成します。
+pub trait GenAction<T> {
+    #[allow(missing_docs)]
+    fn gen_action<R: Rng>(rng: &mut R) -> T;
+}
+
 /// 畳み込まれた値を生成します。
 pub trait GenFoldedValue<T> {
     #[allow(missing_docs)]

--- a/crates/utils/query_test_2/src/query.rs
+++ b/crates/utils/query_test_2/src/query.rs
@@ -8,6 +8,7 @@ impl<T> Query for Get<T> {
     type Output = T;
     const NAME: &'static str = "get";
 }
+
 /// 特定のインデックスの要素を置き換えるクエリです。
 pub struct Set<T>(PhantomData<T>);
 impl<T> Query for Set<T> {
@@ -15,6 +16,7 @@ impl<T> Query for Set<T> {
     type Output = ();
     const NAME: &'static str = "set";
 }
+
 /// 列のある範囲を単位元のある結合的な演算で畳み込みます。
 pub struct Fold<T>(PhantomData<T>);
 impl<T> Query for Fold<T> {
@@ -22,6 +24,7 @@ impl<T> Query for Fold<T> {
     type Output = T;
     const NAME: &'static str = "fold";
 }
+
 /// `f(i) = (fold(start..i) <= value)` としたときに、`range.contains(i) && f(i) && !f(i + 1)` となる `i`
 /// を一つ探します。
 pub struct ForwardUpperBoundByKey<T, U, P>(PhantomData<(T, U, P)>);
@@ -30,6 +33,7 @@ impl<T, U, P: utils::Project<T, U>> Query for ForwardUpperBoundByKey<T, U, P> {
     type Output = usize;
     const NAME: &'static str = "forward_upper_bound_by_key";
 }
+
 /// `f(i) = (fold(i..end) <= value)` としたときに、`range.contains(i) && f(i) && !f(i + 1)` となる `i`
 /// を一つ探します。
 pub struct BackwardUpperBoundByKey<T, U, P>(PhantomData<(T, U, P)>);
@@ -37,4 +41,12 @@ impl<T, U, P: utils::Project<T, U>> Query for BackwardUpperBoundByKey<T, U, P> {
     type Param = (Range<usize>, U);
     type Output = usize;
     const NAME: &'static str = "backward_upper_bound_by_key";
+}
+
+/// 範囲作用をします。
+pub struct RangeApply<T>(PhantomData<T>);
+impl<T> Query for RangeApply<T> {
+    type Param = (Range<usize>, T);
+    type Output = ();
+    const NAME: &'static str = "range_apply";
 }

--- a/crates/utils/query_test_2/src/solve.rs
+++ b/crates/utils/query_test_2/src/solve.rs
@@ -5,6 +5,11 @@ pub trait Solve<Q: Query> {
     #[allow(missing_docs)]
     fn solve(&self, param: Q::Param) -> Q::Output;
 }
+/// 自分を書き換えて、値も返します。
+pub trait SolveMut<Q: Query> {
+    #[allow(missing_docs)]
+    fn solve_mut(&mut self, param: Q::Param) -> Q::Output;
+}
 /// 自分を書き換えます。
 pub trait Mutate<Q: Query<Output = ()>> {
     #[allow(missing_docs)]
@@ -13,4 +18,10 @@ pub trait Mutate<Q: Query<Output = ()>> {
 /// 結果が正しければ `true`, 誤っていれば `false` を返します。
 pub trait Judge<Q: Query> {
     fn judge(&self, param: Q::Param, output: Q::Output) -> bool;
+}
+
+impl<Q: Query, T: Solve<Q>> SolveMut<Q> for T {
+    fn solve_mut(&mut self, param: Q::Param) -> Q::Output {
+        self.solve(param)
+    }
 }

--- a/crates/utils/query_test_2/src/solve.rs
+++ b/crates/utils/query_test_2/src/solve.rs
@@ -6,7 +6,7 @@ pub trait Solve<Q: Query> {
     fn solve(&self, param: Q::Param) -> Q::Output;
 }
 /// 自分を書き換えます。
-pub trait Mutate<Q: Query> {
+pub trait Mutate<Q: Query<Output = ()>> {
     #[allow(missing_docs)]
     fn mutate(&mut self, param: Q::Param);
 }

--- a/crates/utils/query_test_2/src/testing.rs
+++ b/crates/utils/query_test_2/src/testing.rs
@@ -97,7 +97,7 @@ where
             }
         }
     }
-    pub fn mutate<Q: Query>(&mut self)
+    pub fn mutate<Q: Query<Output = ()>>(&mut self)
     where
         Q::Param: Clone + Debug,
         Q::Output: Clone + Debug + PartialEq,

--- a/crates/utils/query_test_2/src/testing.rs
+++ b/crates/utils/query_test_2/src/testing.rs
@@ -72,6 +72,33 @@ where
             }
         }
     }
+    pub fn compare_mut<Q: Query>(&mut self)
+    where
+        Q::Param: Clone + Debug + Clone,
+        Q::Output: Clone + Debug + Clone + PartialEq,
+        B: Gen<Q, G> + solve::SolveMut<Q>,
+        F: solve::SolveMut<Q>,
+    {
+        let param = self.brute.gen::<R>(self.rng_mut().deref_mut());
+        let expected = self.brute.solve_mut(param.clone());
+        let output = self.fast.solve_mut(param.clone());
+
+        let verdict = expected == output;
+        let logger = logger::Logger {
+            tester: self,
+            param,
+            output: Some(output),
+            expected: Some(expected),
+            marker: PhantomData::<Q>,
+        };
+        match verdict {
+            true => logger.passing(),
+            false => {
+                logger.failing();
+                panic!("Failed in a test.");
+            }
+        }
+    }
     pub fn judge<Q: Query>(&self)
     where
         Q::Param: Clone + Debug,

--- a/crates/utils/query_test_2/src/testing/logger.rs
+++ b/crates/utils/query_test_2/src/testing/logger.rs
@@ -16,7 +16,10 @@ where
     T::Brute: Debug + Clone,
     T::Fast: Debug + Clone,
 {
-    pub fn mutate(&self) {
+    pub fn mutate(&self)
+    where
+        Q: Query<Output = ()>,
+    {
         use config::Passing;
         match self.tester.config().passing {
             Passing::Short => self.mutate_short(),

--- a/crates/utils/type_traits/src/actions.rs
+++ b/crates/utils/type_traits/src/actions.rs
@@ -67,7 +67,7 @@ impl<T: OpN> Assoc for Pow<T> {
 }
 impl<T: OpN> Identity for Pow<T> {
     fn identity() -> Self {
-        Pow(0, PhantomData)
+        Pow(1, PhantomData)
     }
 }
 impl<T: OpN> Action for Pow<T> {

--- a/crates/utils/type_traits/src/actions.rs
+++ b/crates/utils/type_traits/src/actions.rs
@@ -1,0 +1,98 @@
+use super::{Action, Assoc, Element, Identity};
+
+/// 1 付加です。
+impl<T: Action> Action for Option<T> {
+    type Space = T::Space;
+    fn acted(self, rhs: T::Space) -> T::Space {
+        match self {
+            Some(x) => x.acted(rhs),
+            None => rhs,
+        }
+    }
+}
+
+/// 代入作用 （`x (y) = x` で定義される作用）です。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Update<T>(pub T);
+triv_wrapper! { Update<T> }
+impl<T: Element> Assoc for Update<T> {
+    fn op(self, _rhs: Self) -> Self {
+        self
+    }
+}
+impl<T: Element> Action for Update<T> {
+    type Space = T;
+    fn acted(self, _rhs: T) -> T {
+        self.0
+    }
+}
+
+/// 随伴作用（`x (y) = x * y` で定義される作用）です。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Adj<T>(pub T);
+triv_wrapper! { Adj<T> }
+impl<T: Assoc> Assoc for Adj<T> {
+    fn op(self, rhs: Self) -> Self {
+        Adj(self.0.op(rhs.0))
+    }
+}
+impl<T: Identity> Identity for Adj<T> {
+    fn identity() -> Self {
+        Adj(T::identity())
+    }
+}
+impl<T: Assoc> Action for Adj<T> {
+    type Space = T;
+    fn acted(self, rhs: T) -> T {
+        self.0.op(rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_impl::assert_impl;
+
+    #[test]
+    fn test_update() {
+        use crate::binary::Add;
+        assert_impl!(Assoc: Update<()>);
+        assert_impl!(!Identity: Update<()>);
+        assert_impl!(Action<Space = ()>: Update<()>);
+
+        assert_impl!(Assoc: Update<Add<u32>>);
+        assert_impl!(!Identity: Update<Add<u32>>);
+        assert_impl!(Action<Space = Add<u32>>: Update<Add<u32>>);
+
+        assert_impl!(Assoc: Option<Update<()>>);
+        assert_impl!(Identity: Option<Update<()>>);
+        assert_impl!(Action<Space = ()>: Option<Update<()>>);
+
+        assert_eq!(Update(3).acted(2), 3);
+        assert_eq!(Some(Update(3)).acted(2), 3);
+        assert_eq!(None::<Update<u32>>.acted(2), 2);
+        assert_eq!(<Option<Update<u32>> as Identity>::identity(), None);
+    }
+
+    #[test]
+    fn test_adj() {
+        use crate::binary::Add;
+        assert_impl!(!Assoc: Adj<()>);
+        assert_impl!(!Identity: Adj<()>);
+        assert_impl!(!Action: Adj<()>);
+
+        assert_impl!(Assoc: Adj<Add<u32>>);
+        assert_impl!(Identity: Adj<Add<u32>>);
+        assert_impl!(Action<Space = Add<u32>>: Adj<Add<u32>>);
+
+        assert_impl!(!Assoc: Option<Adj<()>>);
+        assert_impl!(!Identity: Option<Adj<()>>);
+        assert_impl!(!Action<Space = ()>: Option<Adj<()>>);
+
+        assert_eq!(Adj(Add(3)).acted(Add(2)), Add(5));
+        assert_eq!(Some(Adj(Add(3))).acted(Add(2)), Add(5));
+        assert_eq!(None::<Adj<Add<u32>>>.acted(Add(2)), Add(2));
+        assert_eq!(<Adj<Add<u32>> as Identity>::identity(), Adj(Add(0)));
+        assert_eq!(<Option<Adj<Add<u32>>> as Identity>::identity(), None);
+    }
+}

--- a/crates/utils/type_traits/src/binary.rs
+++ b/crates/utils/type_traits/src/binary.rs
@@ -456,7 +456,7 @@ mod tests {
 
         assert_impl!(Identity: Mul<i64>, Mul<f64>);
         assert_impl!(Commut: Mul<i64>, Mul<f64>);
-        assert_impl!(!OpN: Mul<i64>, Mul<f64>);
+        assert_impl!(OpN: Mul<i64>, Mul<f64>);
 
         assert_impl!(Ord: Mul<i64>);
         assert_impl!(!Ord: Mul<f64>);

--- a/crates/utils/type_traits/src/binary.rs
+++ b/crates/utils/type_traits/src/binary.rs
@@ -1,4 +1,6 @@
-use super::{Assoc, Commut, Element, Identity, MaxValue, MinValue, One, OpN, Peek, Zero};
+use super::{
+    Assoc, Commut, Element, Identity, MaxValue, MinValue, NTimes, One, OpN, Peek, PowN, Zero,
+};
 use std::ops;
 
 /// 長さの情報を追加するラッパーです。
@@ -199,6 +201,14 @@ where
         Add(T::zero())
     }
 }
+impl<T> OpN for Add<T>
+where
+    T: NTimes,
+{
+    fn op_n(self, n: u64) -> Self {
+        Add(self.0.n_times(n))
+    }
+}
 
 /// 乗法を演算として [`Assoc`], [`Identity`] を実装するラッパーです。
 ///
@@ -221,6 +231,14 @@ where
 {
     fn identity() -> Self {
         Mul(T::one())
+    }
+}
+impl<T> OpN for Mul<T>
+where
+    T: PowN,
+{
+    fn op_n(self, n: u64) -> Self {
+        Mul(self.0.pow_n(n))
     }
 }
 

--- a/crates/utils/type_traits/src/binary.rs
+++ b/crates/utils/type_traits/src/binary.rs
@@ -1,4 +1,4 @@
-use super::{Assoc, Commut, Element, Identity, One, OpN, Peek, Zero};
+use super::{Assoc, Commut, Element, Identity, MaxValue, MinValue, One, OpN, Peek, Zero};
 use std::ops;
 
 macro_rules! triv_wrapper {
@@ -93,7 +93,55 @@ impl<T: ops::BitXor<Output = T> + Zero> OpN for BitXor<T> {
     }
 }
 
-/// `ops::Add` を演算として [`Assoc`], [`Identity`] を実装するラッパーです。
+/// Min を演算として [`Assoc`], [`Identity`] を実装するラッパーです。
+///
+/// [`Assoc`]: traits.Assoc.html
+/// [`Identity`]: traits.Identity.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Min<T>(pub T);
+triv_wrapper! { Min<T> }
+impl<T> Assoc for Min<T>
+where
+    T: Ord + Element,
+{
+    fn op(self, rhs: Self) -> Self {
+        Min(self.0.min(rhs.0))
+    }
+}
+impl<T> Identity for Min<T>
+where
+    T: MaxValue,
+{
+    fn identity() -> Self {
+        Min(T::max_value())
+    }
+}
+
+/// Max を演算として [`Assoc`], [`Identity`] を実装するラッパーです。
+///
+/// [`Assoc`]: traits.Assoc.html
+/// [`Identity`]: traits.Identity.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Max<T>(pub T);
+triv_wrapper! { Max<T> }
+impl<T> Assoc for Max<T>
+where
+    T: Ord + Element,
+{
+    fn op(self, rhs: Self) -> Self {
+        Max(self.0.max(rhs.0))
+    }
+}
+impl<T> Identity for Max<T>
+where
+    T: MinValue,
+{
+    fn identity() -> Self {
+        Max(T::min_value())
+    }
+}
+
+/// 加法を演算として [`Assoc`], [`Identity`] を実装するラッパーです。
 ///
 /// [`Assoc`]: traits.Assoc.html
 /// [`Identity`]: traits.Identity.html
@@ -117,7 +165,7 @@ where
     }
 }
 
-/// `ops::Mul` を演算として [`Assoc`], [`Identity`] を実装するラッパーです。
+/// 乗法を演算として [`Assoc`], [`Identity`] を実装するラッパーです。
 ///
 /// [`Assoc`]: traits.Assoc.html
 /// [`Identity`]: traits.Identity.html

--- a/crates/utils/type_traits/src/lib.rs
+++ b/crates/utils/type_traits/src/lib.rs
@@ -1,7 +1,7 @@
 #![warn(missing_docs)]
 //! 基本的なトレイトを定義します。
 //!
-//! TODO: 代数関連を分離します。
+//! TODO: [ac-adapter-rs#50](https://github.com/ngtkana/ac-adapter-rs/issues/50)
 //!
 //! # 代数関連
 //!
@@ -9,20 +9,20 @@
 //!
 //! ## 二項演算
 //!
-//! 結合的な演算 [`op`] を備えた [`Assoc`] を継承します。
+//! 二項演算は結合的であるもののみを扱います。基本トレイトは [`Assoc`] であり、追加で性質を課すときには、
+//! この次のようなトレイトを実装すると良いです。これらはすべて、[`Assoc`]
+//! を継承します。具体的な演算は [`binary`] モジュールに入れてあります。
 //!
 //! - [`Identity`] : 単位元を返す写像 [`identity`] を備えています。
 //! - [`Commut`] : 可換性を表すマーカートレイトです。
 //! - [`OpN`] : N 乗を高速に計算する写像 [`op_n`] を備えています。
 //!
-//! 各種ラッパーも [`binary`] に定義されています。
+//! ## 範囲作用（「作用」に組み込むべき？）
+//!
+//! [`RangeAction`] は [`op`] と可換になるように [`Assoc`] に作用します。
 //!
 //!
-//! ## 作用
-//!
-//! [`Action`] は [`op`] と可換になるように [`Assoc`] に作用します。
-//!
-//!
+//! [`binary`]: binary/index.html
 //! [`op`]: traits.Assoc.html#method.op
 //! [`identity`]: traits.Assoc.html#method.identity
 //! [`deg`]: traits.Assoc.html#method.deg
@@ -32,7 +32,7 @@
 //! [`Identity`]: traits.Identity.html
 //! [`Commut`]: traits.Commut.html
 //! [`OpN`]: traits.OpN.html
-//! [`Action`]: traits.Action.html
+//! [`RangeAction`]: traits.RangeAction.html
 
 use std::{cmp, fmt, ops};
 
@@ -41,8 +41,8 @@ mod primitive;
 /// [`Assoc`](traits.Assoc.html) を実装した各種ラッパーさんです。
 pub mod binary;
 
-/// [`Action`](traits.Action.html) を実装した各種ラッパーさんです。
-pub mod actions;
+/// [`RangeAction`](traits.RangeAction.html) を実装した各種ラッパーさんです。
+pub mod range_actions;
 
 /// [`Sized`] + [`Clone`] + [`PartialEq`] です。
 ///
@@ -116,11 +116,11 @@ impl<T: Assoc> Assoc for Grade<T> {
 ///
 /// # 要件
 ///
-/// `A: Action`, `a: A`, `x, y: Action::Space` に対して、次が成り立つことです。
+/// `A: RangeAction`, `a: A`, `x, y: RangeAction::Space` に対して、次が成り立つことです。
 ///
 /// `a.acted(x.op(y)) == a.acted(x).op(a.acted(y))`
 ///
-pub trait Action {
+pub trait RangeAction {
     /// 作用される空間です。
     type Space: Assoc;
     /// 作用関数です。

--- a/crates/utils/type_traits/src/lib.rs
+++ b/crates/utils/type_traits/src/lib.rs
@@ -131,9 +131,13 @@ impl<T: Assoc> Assoc for Grade<T> {
 /// 作用します。
 pub trait Action: Assoc {
     /// 作用される空間です。
-    type Space;
+    type Space: Element;
     /// 作用関数です。
     fn acted(self, x: Self::Space) -> Self::Space;
+    /// 作用します。
+    fn act_mut(self, x: &mut Self::Space) {
+        *x = self.acted(x.clone());
+    }
 }
 
 /// 作用をします。

--- a/crates/utils/type_traits/src/lib.rs
+++ b/crates/utils/type_traits/src/lib.rs
@@ -52,6 +52,8 @@ use std::{cmp, fmt, ops};
 
 mod primitive;
 
+/// [`Action`](traits.Action.html) を実装した各種ラッパーさんです。
+pub mod actions;
 /// [`Assoc`](traits.Assoc.html) を実装した各種ラッパーさんです。
 pub mod binary;
 
@@ -124,6 +126,14 @@ impl<T: Assoc> Assoc for Grade<T> {
             base: self.base.op(rhs.base),
         }
     }
+}
+
+/// 作用します。
+pub trait Action: Assoc {
+    /// 作用される空間です。
+    type Space;
+    /// 作用関数です。
+    fn acted(self, x: Self::Space) -> Self::Space;
 }
 
 /// 作用をします。

--- a/crates/utils/type_traits/src/lib.rs
+++ b/crates/utils/type_traits/src/lib.rs
@@ -179,6 +179,11 @@ pub trait Zero: ops::Add<Output = Self> + ops::AddAssign + Element {
         self == &Self::zero()
     }
 }
+/// `x + x + ... + x` を計算します。
+pub trait NTimes: Zero {
+    /// `x + x + ... + x` を計算します。
+    fn n_times(self, n: u64) -> Self;
+}
 
 /// 乗法の単位元を持つトレイトです。
 pub trait One: ops::Mul<Output = Self> + ops::MulAssign + Element {
@@ -192,6 +197,11 @@ pub trait One: ops::Mul<Output = Self> + ops::MulAssign + Element {
     {
         self == &Self::one()
     }
+}
+/// `x * x * ... * x` を計算します。
+pub trait PowN: One {
+    /// `x + x + ... + x` を計算します。
+    fn pow_n(self, n: u64) -> Self;
 }
 
 /// 単位元を持つ結合的な積を持つ環です。

--- a/crates/utils/type_traits/src/lib.rs
+++ b/crates/utils/type_traits/src/lib.rs
@@ -138,7 +138,7 @@ pub trait MinValue: Ord + Element {
     fn min_value() -> Self;
 }
 
-/// `ops::Add` の単位元（零元）を持つトレイトです。
+/// 加法の単位元（零元）を持つトレイトです。
 pub trait Zero: ops::Add<Output = Self> + ops::AddAssign + Element {
     /// `ops::Add` の単位元（零元）を返します。
     fn zero() -> Self;
@@ -152,7 +152,7 @@ pub trait Zero: ops::Add<Output = Self> + ops::AddAssign + Element {
     }
 }
 
-/// `ops::Mul` の単位元を持つトレイトです。
+/// 乗法の単位元を持つトレイトです。
 pub trait One: ops::Mul<Output = Self> + ops::MulAssign + Element {
     /// `ops::Mul` の単位元を返します。
     fn one() -> Self;

--- a/crates/utils/type_traits/src/lib.rs
+++ b/crates/utils/type_traits/src/lib.rs
@@ -127,6 +127,17 @@ pub trait RangeAction {
     fn acted(self, x: Self::Space) -> Self::Space;
 }
 
+/// `cmp::min` の単位元トレイトです。
+pub trait MaxValue: Ord + Element {
+    #[allow(missing_docs)]
+    fn max_value() -> Self;
+}
+/// `cmp::max` の単位元トレイトです。
+pub trait MinValue: Ord + Element {
+    #[allow(missing_docs)]
+    fn min_value() -> Self;
+}
+
 /// `ops::Add` の単位元（零元）を持つトレイトです。
 pub trait Zero: ops::Add<Output = Self> + ops::AddAssign + Element {
     /// `ops::Add` の単位元（零元）を返します。

--- a/crates/utils/type_traits/src/lib.rs
+++ b/crates/utils/type_traits/src/lib.rs
@@ -34,6 +34,20 @@
 //! [`OpN`]: traits.OpN.html
 //! [`RangeAction`]: traits.RangeAction.html
 
+macro_rules! triv_wrapper {
+    ($name:ident<$T:ident>) => {
+        impl<$T> crate::Peek for $name<$T>
+        where
+            $T: crate::Element,
+        {
+            type Inner = $T;
+            fn peek(&self) -> $T {
+                self.0.clone()
+            }
+        }
+    };
+}
+
 use std::{cmp, fmt, ops};
 
 mod primitive;

--- a/crates/utils/type_traits/src/primitive.rs
+++ b/crates/utils/type_traits/src/primitive.rs
@@ -65,11 +65,27 @@ macro_rules! impl_commut_mul {
         impl Commut for Mul<$T> {}
     };
 }
-macro_rules! impl_op_n {
+macro_rules! impl_op_n_add {
     ($T:ident) => {
         impl OpN for Add<$T> {
             fn op_n(self, n: u64) -> Self {
                 Add(self.0 * n as $T)
+            }
+        }
+    };
+}
+macro_rules! impl_op_n_mul {
+    (@kind int @type $T:ident) => {
+        impl OpN for Mul<$T> {
+            fn op_n(self, n: u64) -> Self {
+                Mul(self.0.pow(n as u32))
+            }
+        }
+    };
+    (@kind float @type $T:ident) => {
+        impl OpN for Mul<$T> {
+            fn op_n(self, n: u64) -> Self {
+                Mul(self.0.powi(n as i32))
             }
         }
     };
@@ -83,7 +99,8 @@ macro_rules! int {
         impl_max_value! { $T }
         impl_commut_add! { $T }
         impl_commut_mul! { $T }
-        impl_op_n! { $T }
+        impl_op_n_add! { $T }
+        impl_op_n_mul! { @kind int @type $T }
         int! { $($rest,)* }
     };
     () => ()
@@ -95,7 +112,8 @@ macro_rules! float {
         impl_one! { @kind float @type $T }
         impl_commut_add! { $T }
         impl_commut_mul! { $T }
-        impl_op_n! { $T }
+        impl_op_n_add! { $T }
+        impl_op_n_mul! { @kind float @type $T }
         float! { $($rest,)* }
     };
     () => ()
@@ -126,6 +144,6 @@ mod tests {
         assert_impl!(Commut: Add<u32>, Add<f32>);
         assert_impl!(Commut: Mul<u32>, Mul<f32>);
         assert_impl!(OpN: Add<u32>, Add<f32>);
-        assert_impl!(!OpN: Mul<u32>, Mul<f32>); // TODO: pow を呼んでも良いかもです。
+        assert_impl!(OpN: Mul<u32>, Mul<f32>);
     }
 }

--- a/crates/utils/type_traits/src/range_actions.rs
+++ b/crates/utils/type_traits/src/range_actions.rs
@@ -1,10 +1,10 @@
-use super::{binary::Len, Action, Commut, OpN};
+use super::{binary::Len, Commut, OpN, RangeAction};
 
 /// アップデート作用です。
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub struct Update<T>(pub T);
 
-impl<T: OpN> Action for Update<T> {
+impl<T: OpN> RangeAction for Update<T> {
     type Space = Len<T>;
     fn acted(self, x: Self::Space) -> Self::Space {
         Len {
@@ -18,7 +18,7 @@ impl<T: OpN> Action for Update<T> {
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub struct Adjoint<T>(pub T);
 
-impl<T: OpN + Commut> Action for Adjoint<T> {
+impl<T: OpN + Commut> RangeAction for Adjoint<T> {
     type Space = Len<T>;
     fn acted(self, x: Self::Space) -> Self::Space {
         Len {


### PR DESCRIPTION
### Description

`dual_segtree` を追加します。

### Contents

- これは双対セグメントツリーです。
- `query_test_2` に `SolveMut` と `RangeApply` を追加です。
- `type_traits` に `NTimes`, `PowN` を追加です。（`Pow` 向けです。これを経由しないと `Add<Fp>` に `Pow` を実装するときに別クレートトレイト問題で怒られてしまいます。）
- `type_traits` に `Action` とそれを実装する `Update`, `Adj`（`Adjoint` のほうがよかったでしょうか）, `Pow` を追加します。