### PR TITLE
Feature/add lazy segtree

### DIFF
--- a/crates/algebra/alg_traits/src/lib.rs
+++ b/crates/algebra/alg_traits/src/lib.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 pub trait Element: Debug + Clone + PartialEq {}
 impl<T: Debug + Clone + PartialEq> Element for T {}
 
-pub trait Assoc {
+pub trait Assoc: std::fmt::Debug {
     type Value: Element;
     fn op(lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn op_left(lhs: &mut Self::Value, rhs: Self::Value) {

--- a/crates/algebra/alg_traits/src/lib.rs
+++ b/crates/algebra/alg_traits/src/lib.rs
@@ -28,6 +28,7 @@ pub trait Action: Assoc {
     }
 }
 
+// Option
 impl<T: Assoc> Assoc for Option<T> {
     type Value = Option<T::Value>;
     fn op(lhs: Option<T::Value>, rhs: Option<T::Value>) -> Self::Value {
@@ -51,5 +52,18 @@ impl<A: Action> Action for Option<A> {
         } else {
             x
         }
+    }
+}
+
+// Tuple of two types
+impl<T: Assoc, U: Assoc> Assoc for (T, U) {
+    type Value = (T::Value, U::Value);
+    fn op(lhs: Self::Value, rhs: Self::Value) -> Self::Value {
+        (T::op(lhs.0, rhs.0), U::op(lhs.1, rhs.1))
+    }
+}
+impl<T: Identity, U: Identity> Identity for (T, U) {
+    fn identity() -> <Self as Assoc>::Value {
+        (T::identity(), U::identity())
     }
 }

--- a/crates/algebra/alg_traits/src/lib.rs
+++ b/crates/algebra/alg_traits/src/lib.rs
@@ -20,3 +20,11 @@ pub trait Assoc {
 pub trait Identity: Assoc {
     fn identity() -> Self::Value;
 }
+pub trait Action {
+    type Operator: Element;
+    type Point: Element;
+    fn op(operator: Self::Operator, point: Self::Point) -> Self::Point;
+    fn op_assign(operator: Self::Operator, point: &mut Self::Point) {
+        *point = Self::op(operator, point.clone())
+    }
+}

--- a/crates/algebra/alg_traits/src/lib.rs
+++ b/crates/algebra/alg_traits/src/lib.rs
@@ -20,11 +20,10 @@ pub trait Assoc {
 pub trait Identity: Assoc {
     fn identity() -> Self::Value;
 }
-pub trait Action {
-    type Operator: Element;
+pub trait Action: Assoc {
     type Point: Element;
-    fn op(operator: Self::Operator, point: Self::Point) -> Self::Point;
-    fn op_assign(operator: Self::Operator, point: &mut Self::Point) {
-        *point = Self::op(operator, point.clone())
+    fn act(a: Self::Value, x: Self::Point) -> Self::Point;
+    fn act_assign(a: Self::Value, x: &mut Self::Point) {
+        *x = Self::act(a, x.clone());
     }
 }

--- a/crates/algebra/alg_traits/src/lib.rs
+++ b/crates/algebra/alg_traits/src/lib.rs
@@ -27,3 +27,29 @@ pub trait Action: Assoc {
         *x = Self::act(a, x.clone());
     }
 }
+
+impl<T: Assoc> Assoc for Option<T> {
+    type Value = Option<T::Value>;
+    fn op(lhs: Option<T::Value>, rhs: Option<T::Value>) -> Self::Value {
+        match (lhs, rhs) {
+            (Some(lhs), Some(rhs)) => Some(T::op(lhs, rhs)),
+            (x, None) => x,
+            (None, y) => y,
+        }
+    }
+}
+impl<T: Assoc> Identity for Option<T> {
+    fn identity() -> Option<T::Value> {
+        None
+    }
+}
+impl<A: Action> Action for Option<A> {
+    type Point = A::Point;
+    fn act(a: Option<A::Value>, x: A::Point) -> A::Point {
+        if let Some(a) = a {
+            A::act(a, x)
+        } else {
+            x
+        }
+    }
+}

--- a/crates/algolib/lazy_segtree/Cargo.toml
+++ b/crates/algolib/lazy_segtree/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "lazy_segtree"
+version = "0.1.0"
+authors = ["ngtkana <ngtkana@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+alg_traits = { path = "../../algebra/alg_traits" }
+open = { path = "../../utils/open" }
+
+[dev-dependencies.query_test]
+git = "https://github.com/ngtkana/query_test.git"
+branch = "main"
+package = "query_test"
+
+[dev-dependencies]
+rand = "0.7.3"
+test_vector2 = { path = "../../test_tools/test_vector2" }

--- a/crates/algolib/lazy_segtree/Cargo.toml
+++ b/crates/algolib/lazy_segtree/Cargo.toml
@@ -12,7 +12,7 @@ open = { path = "../../utils/open" }
 
 [dev-dependencies.query_test]
 git = "https://github.com/ngtkana/query_test.git"
-branch = "main"
+tag = "v0.1.0"
 package = "query_test"
 
 [dev-dependencies]

--- a/crates/algolib/lazy_segtree/Cargo.toml
+++ b/crates/algolib/lazy_segtree/Cargo.toml
@@ -18,3 +18,6 @@ package = "query_test"
 [dev-dependencies]
 rand = "0.7.3"
 test_vector2 = { path = "../../test_tools/test_vector2" }
+yosupo = { path = "../../test_tools/yosupo" }
+ngtio = { path = "../../utils/ngtio" }
+fp2 = { path = "../../utils/fp2" }

--- a/crates/algolib/lazy_segtree/src/lib.rs
+++ b/crates/algolib/lazy_segtree/src/lib.rs
@@ -46,3 +46,9 @@ where
         todo!()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    mod impl_query;
+    use super::LazySegtree;
+}

--- a/crates/algolib/lazy_segtree/src/lib.rs
+++ b/crates/algolib/lazy_segtree/src/lib.rs
@@ -1,33 +1,125 @@
 #![allow(dead_code, unused_variables, unused_imports)]
 use alg_traits::{Action, Identity};
-use std::ops::{Range, RangeBounds};
+use std::{
+    cell::RefCell,
+    ops::{DerefMut, Range, RangeBounds},
+};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct LazySegtree<A: Action, T: Identity> {
+    lg: u32,
     len: usize,
-    lazy: std::cell::RefCell<Vec<A::Value>>,
-    table: std::cell::RefCell<Vec<T::Value>>,
+    lazy: RefCell<Vec<A::Value>>,
+    table: RefCell<Vec<T::Value>>,
 }
 
 impl<A, T> LazySegtree<A, T>
 where
-    A: Action<Point = T::Value>,
+    A: Action<Point = T::Value> + Identity,
     T: Identity,
 {
     fn from_slice(src: &[T::Value]) -> Self {
-        todo!()
+        let len = src.len();
+        let mut table = vec![T::identity(); 2 * len];
+        table[len..].clone_from_slice(src);
+        for i in (1..len).rev() {
+            table[i] = T::op(table[2 * i].clone(), table[2 * i + 1].clone());
+        }
+        Self {
+            lg: len.next_power_of_two().trailing_zeros(),
+            len,
+            table: RefCell::new(table),
+            lazy: RefCell::new(std::iter::repeat(A::identity()).take(len).collect()),
+        }
     }
 
-    fn set(&mut self, i: usize, x: T::Value) {
-        todo!()
+    fn set(&mut self, mut i: usize, x: T::Value) {
+        i += self.len;
+        for p in (1..=self.lg).rev() {
+            self.push(i >> p);
+        }
+        self.table.borrow_mut()[i] = x;
+        for p in 1..=self.lg {
+            self.update(i >> p);
+        }
     }
 
     fn fold(&self, range: impl RangeBounds<usize>) -> T::Value {
-        todo!()
+        let Range { mut start, mut end } = open::open(self.len, range);
+        assert!(start <= end, "変な区間");
+        assert!(end <= self.len, "範囲外");
+        if start == end {
+            T::identity()
+        } else {
+            start += self.len;
+            end += self.len;
+            for p in (1..=self.lg).rev() {
+                if ((start >> p) << p) != start {
+                    self.push(start >> p);
+                }
+                if ((end >> p) << p) != end {
+                    self.push(end >> p);
+                }
+            }
+
+            let mut left = T::identity();
+            let mut right = T::identity();
+            while start != end {
+                if start % 2 == 1 {
+                    T::op_left(&mut left, self.table.borrow()[start].clone());
+                    start += 1;
+                }
+                if end % 2 == 1 {
+                    end -= 1;
+                    T::op_right(self.table.borrow()[end].clone(), &mut right);
+                }
+                start >>= 1;
+                end >>= 1;
+            }
+            T::op(left, right)
+        }
     }
 
     fn apply(&mut self, range: impl RangeBounds<usize>, a: A::Value) {
-        todo!()
+        let Range { mut start, mut end } = open::open(self.len, range);
+        if start != end {
+            start += self.len;
+            end += self.len;
+            for p in (1..=self.lg).rev() {
+                if ((start >> p) << p) != start {
+                    self.push(start >> p);
+                }
+                if ((end >> p) << p) != end {
+                    self.push((end - 1) >> p);
+                }
+            }
+            {
+                let orig_start = start;
+                let orig_end = end;
+                while start != end {
+                    if start % 2 == 1 {
+                        self.apply_subtree(start, a.clone());
+                        start += 1;
+                    }
+                    if end % 2 == 1 {
+                        end -= 1;
+                        self.apply_subtree(end, a.clone());
+                    }
+                    start >>= 1;
+                    end >>= 1;
+                }
+                start = orig_start;
+                end = orig_end;
+            }
+            for p in 1..=self.lg {
+                if ((start >> p) << p) != start {
+                    self.update(start >> p);
+                }
+                if ((end >> p) << p) != end {
+                    self.update((end - 1) >> p);
+                }
+            }
+        }
     }
 
     fn search_forward<R, F>(&self, range: R, pred: F) -> usize
@@ -44,6 +136,36 @@ where
         F: FnMut(&T::Value) -> bool,
     {
         todo!()
+    }
+
+    fn peek_one(&self, mut i: usize) -> T::Value {
+        i += self.len;
+        let mut x = self.table.borrow()[i].clone();
+        for p in (1..=self.lg).rev() {
+            A::act_assign(self.lazy.borrow()[i >> p].clone(), &mut x);
+        }
+        x
+    }
+    fn peek(&self) -> Vec<T::Value> {
+        (0..self.len).map(|i| self.peek_one(i)).collect::<Vec<_>>()
+    }
+    fn update(&self, i: usize) {
+        let x = T::op(
+            self.table.borrow()[2 * i].clone(),
+            self.table.borrow()[2 * i + 1].clone(),
+        );
+        self.table.borrow_mut()[i] = x;
+    }
+    fn push(&self, i: usize) {
+        let x = std::mem::replace(&mut self.lazy.borrow_mut()[i], A::identity());
+        self.apply_subtree(2 * i, x.clone());
+        self.apply_subtree(2 * i + 1, x);
+    }
+    fn apply_subtree(&self, i: usize, a: A::Value) {
+        A::act_assign(a.clone(), &mut self.table.borrow_mut()[i]);
+        if i < self.len {
+            A::op_right(a, &mut self.lazy.borrow_mut()[i]);
+        }
     }
 }
 
@@ -78,13 +200,8 @@ mod tests {
         struct A {}
         impl Assoc for A {
             type Value = u32;
-            fn op(a: u32, b: u32) -> u32 {
-                a + b
-            }
-        }
-        impl Identity for A {
-            fn identity() -> u32 {
-                0
+            fn op(a: u32, _b: u32) -> u32 {
+                a
             }
         }
         impl Action for A {
@@ -111,6 +228,11 @@ mod tests {
                 rng.gen_range(0, 100)
             }
         }
+        impl test_vector2::GenActor<Option<A>> for G {
+            fn gen_actor(rng: &mut impl Rng) -> Option<u32> {
+                Some(rng.gen_range(0, 100))
+            }
+        }
 
         struct P {}
         impl queries::Pred<(u32, u32), u32> for P {
@@ -119,16 +241,15 @@ mod tests {
             }
         }
 
-        let mut tester = Tester::<A, X, G>::new(StdRng::seed_from_u64(42));
+        let mut tester = Tester::<Option<A>, X, G>::new(StdRng::seed_from_u64(42));
         for _ in 0..4 {
             tester.initialize();
             for _ in 0..100 {
-                let command = tester.rng_mut().gen_range(0, 4);
+                let command = tester.rng_mut().gen_range(0, 3);
                 match command {
                     0 => tester.mutate::<queries::Set<_>>(),
                     1 => tester.compare::<queries::Fold<_>>(),
-                    2 => tester.judge::<queries::SearchForward<_, _, P>>(),
-                    3 => tester.judge::<queries::SearchBackward<_, _, P>>(),
+                    2 => tester.mutate::<queries::RangeApply<_>>(),
                     _ => unreachable!(),
                 }
             }

--- a/crates/algolib/lazy_segtree/src/lib.rs
+++ b/crates/algolib/lazy_segtree/src/lib.rs
@@ -51,4 +51,87 @@ where
 mod tests {
     mod impl_query;
     use super::LazySegtree;
+
+    use alg_traits::{Action, Assoc, Identity};
+    use rand::prelude::*;
+    use test_vector2::{queries, Vector};
+
+    type Tester<A, T, G> = query_test::Tester<StdRng, Vector<T>, crate::LazySegtree<A, T>, G>;
+
+    #[test]
+    fn test_update_add_u32() {
+        #[derive(Debug, Clone, PartialEq, Copy, Eq)]
+        struct X {}
+        impl Assoc for X {
+            type Value = (u32, u32);
+            fn op((x0, y0): (u32, u32), (x1, y1): (u32, u32)) -> (u32, u32) {
+                (x0 + x1, y0 + y1)
+            }
+        }
+        impl Identity for X {
+            fn identity() -> (u32, u32) {
+                (0, 0)
+            }
+        }
+
+        #[derive(Debug, Clone, PartialEq, Copy, Eq)]
+        struct A {}
+        impl Assoc for A {
+            type Value = u32;
+            fn op(a: u32, b: u32) -> u32 {
+                a + b
+            }
+        }
+        impl Identity for A {
+            fn identity() -> u32 {
+                0
+            }
+        }
+        impl Action for A {
+            type Point = (u32, u32);
+            fn act(a: u32, x: (u32, u32)) -> (u32, u32) {
+                let len = x.1;
+                (a * len, len)
+            }
+        }
+
+        struct G {}
+        impl test_vector2::GenLen for G {
+            fn gen_len(rng: &mut impl Rng) -> usize {
+                rng.gen_range(1, 20)
+            }
+        }
+        impl test_vector2::GenValue<(u32, u32)> for G {
+            fn gen_value(rng: &mut impl Rng) -> (u32, u32) {
+                (rng.gen_range(0, 20), 1)
+            }
+        }
+        impl test_vector2::GenKey<u32> for G {
+            fn gen_key(rng: &mut impl Rng) -> u32 {
+                rng.gen_range(0, 100)
+            }
+        }
+
+        struct P {}
+        impl queries::Pred<(u32, u32), u32> for P {
+            fn pred(&(x, _): &(u32, u32), &y: &u32) -> bool {
+                x <= y
+            }
+        }
+
+        let mut tester = Tester::<A, X, G>::new(StdRng::seed_from_u64(42));
+        for _ in 0..4 {
+            tester.initialize();
+            for _ in 0..100 {
+                let command = tester.rng_mut().gen_range(0, 4);
+                match command {
+                    0 => tester.mutate::<queries::Set<_>>(),
+                    1 => tester.compare::<queries::Fold<_>>(),
+                    2 => tester.judge::<queries::SearchForward<_, _, P>>(),
+                    3 => tester.judge::<queries::SearchBackward<_, _, P>>(),
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
 }

--- a/crates/algolib/lazy_segtree/src/lib.rs
+++ b/crates/algolib/lazy_segtree/src/lib.rs
@@ -172,6 +172,7 @@ where
 #[cfg(test)]
 mod tests {
     mod impl_query;
+    mod range_affine_range_sum;
     use super::LazySegtree;
 
     use alg_traits::{Action, Assoc, Identity};

--- a/crates/algolib/lazy_segtree/src/lib.rs
+++ b/crates/algolib/lazy_segtree/src/lib.rs
@@ -1,0 +1,48 @@
+#![allow(dead_code, unused_variables, unused_imports)]
+use alg_traits::{Action, Identity};
+use std::ops::{Range, RangeBounds};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LazySegtree<A: Action, T: Identity> {
+    len: usize,
+    lazy: std::cell::RefCell<Vec<A::Value>>,
+    table: std::cell::RefCell<Vec<T::Value>>,
+}
+
+impl<A, T> LazySegtree<A, T>
+where
+    A: Action<Point = T::Value>,
+    T: Identity,
+{
+    fn from_slice(src: &[T::Value]) -> Self {
+        todo!()
+    }
+
+    fn set(&mut self, i: usize, x: T::Value) {
+        todo!()
+    }
+
+    fn fold(&self, range: impl RangeBounds<usize>) -> T::Value {
+        todo!()
+    }
+
+    fn apply(&mut self, range: impl RangeBounds<usize>, a: A::Value) {
+        todo!()
+    }
+
+    fn search_forward<R, F>(&self, range: R, pred: F) -> usize
+    where
+        R: RangeBounds<usize>,
+        F: FnMut(&T::Value) -> bool,
+    {
+        todo!()
+    }
+
+    fn search_backward<R, F>(&self, range: R, pred: F) -> usize
+    where
+        R: RangeBounds<usize>,
+        F: FnMut(&T::Value) -> bool,
+    {
+        todo!()
+    }
+}

--- a/crates/algolib/lazy_segtree/src/tests/impl_query.rs
+++ b/crates/algolib/lazy_segtree/src/tests/impl_query.rs
@@ -6,7 +6,7 @@ use test_vector2::{queries, Vector};
 
 impl<A, T> FromBrute for LazySegtree<A, T>
 where
-    A: Action<Point = T::Value>,
+    A: Action<Point = T::Value> + Identity,
     T: Identity,
 {
     type Brute = Vector<T>;
@@ -17,7 +17,7 @@ where
 
 impl<A, T> solve::Mutate<queries::Set<T::Value>> for LazySegtree<A, T>
 where
-    A: Action<Point = T::Value>,
+    A: Action<Point = T::Value> + Identity,
     T: Identity,
 {
     fn mutate(&mut self, (i, x): (usize, T::Value)) {
@@ -27,7 +27,7 @@ where
 
 impl<A, T> solve::Solve<queries::Fold<T::Value>> for LazySegtree<A, T>
 where
-    A: Action<Point = T::Value>,
+    A: Action<Point = T::Value> + Identity,
     T: Identity,
 {
     fn solve(&self, range: Range<usize>) -> T::Value {
@@ -37,7 +37,7 @@ where
 
 impl<A, T, U, P> solve::Solve<queries::SearchForward<T::Value, U, P>> for LazySegtree<A, T>
 where
-    A: Action<Point = T::Value>,
+    A: Action<Point = T::Value> + Identity,
     T: Identity,
     P: queries::Pred<T::Value, U>,
 {
@@ -48,11 +48,21 @@ where
 
 impl<A, T, U, P> solve::Solve<queries::SearchBackward<T::Value, U, P>> for LazySegtree<A, T>
 where
-    A: Action<Point = T::Value>,
+    A: Action<Point = T::Value> + Identity,
     T: Identity,
     P: queries::Pred<T::Value, U>,
 {
     fn solve(&self, (range, key): (Range<usize>, U)) -> usize {
         self.search_backward(range, |t| P::pred(t, &key))
+    }
+}
+
+impl<A, T> solve::Mutate<queries::RangeApply<A>> for LazySegtree<A, T>
+where
+    A: Action<Point = T::Value> + Identity,
+    T: Identity,
+{
+    fn mutate(&mut self, (range, a): (Range<usize>, A::Value)) {
+        self.apply(range, a);
     }
 }

--- a/crates/algolib/lazy_segtree/src/tests/impl_query.rs
+++ b/crates/algolib/lazy_segtree/src/tests/impl_query.rs
@@ -1,0 +1,58 @@
+use crate::LazySegtree;
+use alg_traits::{Action, Identity};
+use query_test::{solve, FromBrute};
+use std::ops::Range;
+use test_vector2::{queries, Vector};
+
+impl<A, T> FromBrute for LazySegtree<A, T>
+where
+    A: Action<Point = T::Value>,
+    T: Identity,
+{
+    type Brute = Vector<T>;
+    fn from_brute(brute: &Vector<T>) -> Self {
+        Self::from_slice(&brute.0)
+    }
+}
+
+impl<A, T> solve::Mutate<queries::Set<T::Value>> for LazySegtree<A, T>
+where
+    A: Action<Point = T::Value>,
+    T: Identity,
+{
+    fn mutate(&mut self, (i, x): (usize, T::Value)) {
+        self.set(i, x);
+    }
+}
+
+impl<A, T> solve::Solve<queries::Fold<T::Value>> for LazySegtree<A, T>
+where
+    A: Action<Point = T::Value>,
+    T: Identity,
+{
+    fn solve(&self, range: Range<usize>) -> T::Value {
+        self.fold(range)
+    }
+}
+
+impl<A, T, U, P> solve::Solve<queries::SearchForward<T::Value, U, P>> for LazySegtree<A, T>
+where
+    A: Action<Point = T::Value>,
+    T: Identity,
+    P: queries::Pred<T::Value, U>,
+{
+    fn solve(&self, (range, key): (Range<usize>, U)) -> usize {
+        self.search_forward(range, |t| P::pred(t, &key))
+    }
+}
+
+impl<A, T, U, P> solve::Solve<queries::SearchBackward<T::Value, U, P>> for LazySegtree<A, T>
+where
+    A: Action<Point = T::Value>,
+    T: Identity,
+    P: queries::Pred<T::Value, U>,
+{
+    fn solve(&self, (range, key): (Range<usize>, U)) -> usize {
+        self.search_backward(range, |t| P::pred(t, &key))
+    }
+}

--- a/crates/algolib/lazy_segtree/src/tests/range_affine_range_sum.rs
+++ b/crates/algolib/lazy_segtree/src/tests/range_affine_range_sum.rs
@@ -1,0 +1,66 @@
+use crate::LazySegtree;
+use alg_traits::{arith::Add, Action, Assoc, Identity};
+use std::path::PathBuf;
+use yosupo::YosupoTest;
+
+const PROBLEM_DIR: &'static str =
+    "../../../library-checker-problems/datastructure/range_affine_range_sum";
+
+type Fp = fp2::F998244353;
+
+#[derive(Debug, Clone, PartialEq, Copy, Eq)]
+struct A {}
+impl Assoc for A {
+    type Value = (Fp, Fp);
+    fn op((a, b): (Fp, Fp), (c, d): (Fp, Fp)) -> (Fp, Fp) {
+        (a * c, a * d + b)
+    }
+}
+impl Identity for A {
+    fn identity() -> (Fp, Fp) {
+        (Fp::new(1), Fp::new(0))
+    }
+}
+impl Action for A {
+    type Point = (Fp, usize);
+    fn act((a, b): (Fp, Fp), (x, len): (Fp, usize)) -> (Fp, usize) {
+        (a * x + b * Fp::new(len as i64), len)
+    }
+}
+
+fn main(in_str: &str, out_str: &mut String) {
+    let mut buf = ngtio::with_str(in_str);
+    let n = buf.usize();
+    let q = buf.usize();
+    let a = std::iter::repeat_with(|| (Fp::new(buf.i64()), 1))
+        .take(n)
+        .collect::<Vec<_>>();
+    let mut seg = LazySegtree::<A, (Add<Fp>, Add<usize>)>::from_slice(&a);
+    for _ in 0..q {
+        let command = buf.usize();
+        match command {
+            0 => {
+                let l = buf.usize();
+                let r = buf.usize();
+                let b = Fp::new(buf.i64());
+                let c = Fp::new(buf.i64());
+                seg.apply(l..r, (b, c));
+            }
+            1 => {
+                let l = buf.usize();
+                let r = buf.usize();
+                let ans: Fp = seg.fold(l..r).0;
+                out_str.push_str(&format!("{}\n", ans));
+            }
+            _ => panic!(),
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn range_affine_range_sum() {
+    YosupoTest::new(main, PathBuf::from(PROBLEM_DIR))
+        .generate()
+        .run_all();
+}

--- a/crates/algolib/segtree2/Cargo.toml
+++ b/crates/algolib/segtree2/Cargo.toml
@@ -12,7 +12,7 @@ open = { path = "../../utils/open" }
 
 [dev-dependencies.query_test]
 git = "https://github.com/ngtkana/query_test.git"
-branch = "main"
+tag = "v0.1.0"
 package = "query_test"
 
 [dev-dependencies]

--- a/crates/algolib/segtree2/Cargo.toml
+++ b/crates/algolib/segtree2/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2018"
 
 [dependencies]
 alg_traits = { path = "../../algebra/alg_traits" }
-rand = "0.7.3"
-prettydiff = "0.3.1"
+open = { path = "../../utils/open" }
 
 [dev-dependencies.query_test]
 git = "https://github.com/ngtkana/query_test.git"
@@ -22,4 +21,4 @@ test_vector2 = { path = "../../test_tools/test_vector2" }
 yosupo = { path = "../../test_tools/yosupo" }
 alg_inversion_number = { path = "../../algebra/alg_inversion_number" }
 ngtio = { path = "../../utils/ngtio" }
-assert-impl = "0.1.3"
+rand = "0.7.3"

--- a/crates/algolib/segtree2/src/lib.rs
+++ b/crates/algolib/segtree2/src/lib.rs
@@ -26,7 +26,7 @@ impl<T: Identity> Segtree<T> {
     }
 
     pub fn fold(&self, range: impl RangeBounds<usize>) -> T::Value {
-        let Range { mut start, mut end } = open(self.len, range);
+        let Range { mut start, mut end } = open::open(self.len, range);
         start += self.len;
         end += self.len;
         let mut left = T::identity();
@@ -51,7 +51,7 @@ impl<T: Identity> Segtree<T> {
         range: impl RangeBounds<usize>,
         mut pred: impl FnMut(&T::Value) -> bool,
     ) -> usize {
-        let Range { mut start, mut end } = open(self.len, range);
+        let Range { mut start, mut end } = open::open(self.len, range);
         if start == end {
             start
         } else {
@@ -92,7 +92,7 @@ impl<T: Identity> Segtree<T> {
         range: impl RangeBounds<usize>,
         mut pred: impl FnMut(&T::Value) -> bool,
     ) -> usize {
-        let Range { mut start, mut end } = open(self.len, range);
+        let Range { mut start, mut end } = open::open(self.len, range);
         if start == end {
             start
         } else {
@@ -165,19 +165,6 @@ impl<T: Identity> Segtree<T> {
         }
         root + 1 - self.len
     }
-}
-
-fn open(len: usize, range: impl RangeBounds<usize>) -> Range<usize> {
-    use std::ops::Bound::*;
-    (match range.start_bound() {
-        Unbounded => 0,
-        Included(&x) => x,
-        Excluded(&x) => x + 1,
-    })..(match range.end_bound() {
-        Excluded(&x) => x,
-        Included(&x) => x + 1,
-        Unbounded => len,
-    })
 }
 
 #[cfg(test)]

--- a/crates/algolib/segtree2/src/tests/point_set_range_composite.rs
+++ b/crates/algolib/segtree2/src/tests/point_set_range_composite.rs
@@ -5,6 +5,7 @@ use yosupo::YosupoTest;
 
 type Fp = fp2::F998244353;
 
+#[derive(Debug, Clone, PartialEq)]
 struct X {}
 impl Assoc for X {
     type Value = (Fp, Fp);

--- a/crates/test_tools/queries2/Cargo.toml
+++ b/crates/test_tools/queries2/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2018"
 
 [dependencies.query_test]
 git = "https://github.com/ngtkana/query_test.git"
-branch = "main"
+tag = "v0.1.0"
 package = "query_test"
 
 [dependencies]
+alg_traits = { path = "../../algebra/alg_traits" }
 assert-impl = "0.1.3"

--- a/crates/test_tools/queries2/src/lib.rs
+++ b/crates/test_tools/queries2/src/lib.rs
@@ -1,3 +1,4 @@
+use alg_traits::Assoc;
 use query_test::Query;
 use std::{marker::PhantomData, ops::Range};
 
@@ -12,6 +13,9 @@ pub struct SearchForward<T, U, P>(PhantomData<(T, U, P)>);
 
 #[query_test::query(fn(Range<usize>, U) -> usize)]
 pub struct SearchBackward<T, U, P>(PhantomData<(T, U, P)>);
+
+#[query_test::query(fn(Range<usize>, <A as Assoc>::Value))]
+pub struct RangeApply<A: Assoc>(PhantomData<A>);
 
 pub trait Pred<T, U> {
     fn pred(t: &T, u: &U) -> bool;

--- a/crates/test_tools/test_vector2/Cargo.toml
+++ b/crates/test_tools/test_vector2/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies.query_test]
 git = "https://github.com/ngtkana/query_test.git"
-branch = "main"
+tag = "v0.1.0"
 package = "query_test"
 
 [dependencies]

--- a/crates/test_tools/test_vector2/src/lib.rs
+++ b/crates/test_tools/test_vector2/src/lib.rs
@@ -1,10 +1,11 @@
 pub use queries2 as queries;
 
-use alg_traits::Identity;
+use alg_traits::{Action, Identity};
 use query_test::{solve, Gen, Init};
 use rand::prelude::*;
 use std::ops::Range;
 
+// TODO: うーんでもやっぱり Vec<T> にできる気がします。
 #[derive(Debug, Clone, PartialEq)]
 pub struct Vector<T: Identity>(pub Vec<T::Value>);
 
@@ -55,6 +56,18 @@ where
             && output <= range.end
             && (range.start == output || !pred(output - 1)))
             && (range.end == output || pred(output))
+    }
+}
+
+impl<A, T> solve::Mutate<queries::RangeApply<A>> for Vector<T>
+where
+    A: Action<Point = T::Value>,
+    T: Identity,
+{
+    fn mutate(&mut self, (range, a): (Range<usize>, A::Value)) {
+        self.0[range]
+            .iter_mut()
+            .for_each(|x| A::act_assign(a.clone(), x));
     }
 }
 

--- a/crates/test_tools/test_vector2/src/lib.rs
+++ b/crates/test_tools/test_vector2/src/lib.rs
@@ -83,6 +83,10 @@ pub trait GenKey<T> {
     fn gen_key(rng: &mut impl Rng) -> T;
 }
 
+pub trait GenActor<A: Action> {
+    fn gen_actor(rng: &mut impl Rng) -> A::Value;
+}
+
 impl<T: Identity, G: GenLen + GenValue<T::Value>> Init<G> for Vector<T> {
     fn init(rng: &mut impl Rng) -> Self {
         let len = G::gen_len(rng);
@@ -139,5 +143,16 @@ where
 {
     fn gen(&self, rng: &mut impl Rng) -> (Range<usize>, U) {
         (self.gen_range(rng), G::gen_key(rng))
+    }
+}
+
+impl<A, T, G> Gen<queries::RangeApply<A>, G> for Vector<T>
+where
+    A: Action<Point = T::Value>,
+    T: Identity,
+    G: GenActor<A>,
+{
+    fn gen(&self, rng: &mut impl Rng) -> (Range<usize>, A::Value) {
+        (self.gen_range(rng), G::gen_actor(rng))
     }
 }

--- a/crates/utils/open/Cargo.toml
+++ b/crates/utils/open/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "open"
+version = "0.1.0"
+authors = ["ngtkana <ngtkana@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/utils/open/src/lib.rs
+++ b/crates/utils/open/src/lib.rs
@@ -1,0 +1,14 @@
+use std::ops::{Bound, Range, RangeBounds};
+
+pub fn open(len: usize, range: impl RangeBounds<usize>) -> Range<usize> {
+    use Bound::*;
+    (match range.start_bound() {
+        Unbounded => 0,
+        Included(&x) => x,
+        Excluded(&x) => x + 1,
+    })..(match range.end_bound() {
+        Excluded(&x) => x,
+        Included(&x) => x + 1,
+        Unbounded => len,
+    })
+}


### PR DESCRIPTION
### Description

遅延伝播付きセグツリーを追加します。

### Verification

range_affine_range_sum

### Other contents

- query_test への参照を branch から tag に変更
- open を追加して `RangeBounds -> Range` を楽にします。
-  `Action` トレイトを追加します。
- `(Assoc, Assoc)`, `(Identity, Identity)` を実装します。（任意個数もほしいかもです。）