### PR TITLE
Feature/add lazy segtree

### DIFF
--- a/crates/algolib/lazy_segtree/src/lib.rs
+++ b/crates/algolib/lazy_segtree/src/lib.rs
@@ -33,6 +33,14 @@ where
         }
     }
 
+    fn get(&self, mut i: usize) -> T::Value {
+        i += self.len;
+        for p in (1..=self.lg).rev() {
+            self.push(i >> p);
+        }
+        self.table.borrow()[i].clone()
+    }
+
     fn set(&mut self, mut i: usize, x: T::Value) {
         i += self.len;
         for p in (1..=self.lg).rev() {
@@ -357,9 +365,10 @@ mod tests {
             for _ in 0..1000 {
                 let command = tester.rng_mut().gen_range(0, 10);
                 match command {
-                    0 => tester.mutate::<queries::Set<_>>(),
-                    1 => tester.compare::<queries::Fold<_>>(),
-                    2..=7 => tester.mutate::<queries::RangeApply<_>>(),
+                    0 => tester.compare::<queries::Get<_>>(),
+                    1 => tester.mutate::<queries::Set<_>>(),
+                    2 => tester.compare::<queries::Fold<_>>(),
+                    3..=7 => tester.mutate::<queries::RangeApply<_>>(),
                     8 => tester.judge::<queries::SearchForward<_, u32, P>>(),
                     9 => tester.judge::<queries::SearchBackward<_, u32, P>>(),
                     _ => unreachable!(),

--- a/crates/algolib/lazy_segtree/src/lib.rs
+++ b/crates/algolib/lazy_segtree/src/lib.rs
@@ -85,14 +85,7 @@ where
         if start != end {
             start += self.len;
             end += self.len;
-            for p in (1..=self.lg).rev() {
-                if ((start >> p) << p) != start {
-                    self.push(start >> p);
-                }
-                if ((end >> p) << p) != end {
-                    self.push((end - 1) >> p);
-                }
-            }
+            self.level_range(start..end);
             {
                 let orig_start = start;
                 let orig_end = end;
@@ -122,20 +115,92 @@ where
         }
     }
 
-    fn search_forward<R, F>(&self, range: R, pred: F) -> usize
+    fn search_forward<R, F>(&self, range: R, mut pred: F) -> usize
     where
         R: RangeBounds<usize>,
         F: FnMut(&T::Value) -> bool,
     {
-        todo!()
+        let Range { mut start, mut end } = open::open(self.len, range);
+        if start == end {
+            start
+        } else {
+            start += self.len;
+            end += self.len;
+            self.level_range(start..end);
+
+            let mut crr = T::identity();
+            let mut shift = 0;
+            let orig_start = start;
+            let orig_end = end;
+            while start != end {
+                if start % 2 == 1 {
+                    let nxt = T::op(crr.clone(), self.table.borrow()[start].clone());
+                    if !pred(&nxt) {
+                        return self.search_subtree_forward(crr, start, pred);
+                    }
+                    crr = nxt;
+                    start += 1;
+                }
+                start >>= 1;
+                end >>= 1;
+                shift += 1;
+            }
+            for p in (0..shift).rev() {
+                let end = (orig_end >> p) - 1;
+                if end % 2 == 0 {
+                    let nxt = T::op(crr.clone(), self.table.borrow()[end].clone());
+                    if !pred(&nxt) {
+                        return self.search_subtree_forward(crr, end, pred);
+                    }
+                    crr = nxt;
+                }
+            }
+            orig_end - self.len
+        }
     }
 
-    fn search_backward<R, F>(&self, range: R, pred: F) -> usize
+    fn search_backward<R, F>(&self, range: R, mut pred: F) -> usize
     where
         R: RangeBounds<usize>,
         F: FnMut(&T::Value) -> bool,
     {
-        todo!()
+        let Range { mut start, mut end } = open::open(self.len, range);
+        if start == end {
+            start
+        } else {
+            start += self.len;
+            end += self.len;
+            self.level_range(start..end);
+
+            let mut crr = T::identity();
+            let mut shift = 0;
+            let orig_start = start;
+            let orig_end = end;
+            while start != end {
+                if end % 2 == 1 {
+                    end -= 1;
+                    let nxt = T::op(self.table.borrow()[end].clone(), crr.clone());
+                    if !pred(&nxt) {
+                        return self.search_subtree_backward(crr, end, pred);
+                    }
+                    crr = nxt;
+                }
+                start = (start + 1) >> 1;
+                end >>= 1;
+                shift += 1;
+            }
+            for p in (0..shift).rev() {
+                let start = ((orig_start - 1) >> p) + 1;
+                if start % 2 == 1 {
+                    let nxt = T::op(self.table.borrow()[start].clone(), crr.clone());
+                    if !pred(&nxt) {
+                        return self.search_subtree_backward(crr, start, pred);
+                    }
+                    crr = nxt;
+                }
+            }
+            orig_start - self.len
+        }
     }
 
     fn peek_one(&self, mut i: usize) -> T::Value {
@@ -148,6 +213,50 @@ where
     }
     fn peek(&self) -> Vec<T::Value> {
         (0..self.len).map(|i| self.peek_one(i)).collect::<Vec<_>>()
+    }
+    fn search_subtree_forward<F>(&self, mut crr: T::Value, mut root: usize, mut pred: F) -> usize
+    where
+        F: FnMut(&T::Value) -> bool,
+    {
+        while root < self.len {
+            self.push(root);
+            let nxt = T::op(crr.clone(), self.table.borrow()[root * 2].clone());
+            root = match pred(&nxt) {
+                false => 2 * root,
+                true => {
+                    crr = nxt;
+                    2 * root + 1
+                }
+            };
+        }
+        root - self.len
+    }
+    fn search_subtree_backward<F>(&self, mut crr: T::Value, mut root: usize, mut pred: F) -> usize
+    where
+        F: FnMut(&T::Value) -> bool,
+    {
+        while root < self.len {
+            self.push(root);
+            let nxt = T::op(self.table.borrow()[root * 2 + 1].clone(), crr.clone());
+            root = match pred(&nxt) {
+                false => 2 * root + 1,
+                true => {
+                    crr = nxt;
+                    2 * root
+                }
+            };
+        }
+        root - self.len + 1
+    }
+    fn level_range(&self, Range { start, end }: Range<usize>) {
+        for p in (1..=self.lg).rev() {
+            if ((start >> p) << p) != start {
+                self.push(start >> p);
+            }
+            if ((end >> p) << p) != end {
+                self.push((end - 1) >> p);
+            }
+        }
     }
     fn update(&self, i: usize) {
         let x = T::op(
@@ -216,7 +325,7 @@ mod tests {
         struct G {}
         impl test_vector2::GenLen for G {
             fn gen_len(rng: &mut impl Rng) -> usize {
-                rng.gen_range(1, 20)
+                rng.gen_range(1, 50)
             }
         }
         impl test_vector2::GenValue<(u32, u32)> for G {
@@ -243,16 +352,16 @@ mod tests {
         }
 
         let mut tester = Tester::<Option<A>, X, G>::new(StdRng::seed_from_u64(42));
-        for _ in 0..4 {
+        for _ in 0..10 {
             tester.initialize();
-            for _ in 0..100 {
-                let command = tester.rng_mut().gen_range(0, 5);
+            for _ in 0..1000 {
+                let command = tester.rng_mut().gen_range(0, 10);
                 match command {
                     0 => tester.mutate::<queries::Set<_>>(),
                     1 => tester.compare::<queries::Fold<_>>(),
-                    2 => tester.mutate::<queries::RangeApply<_>>(),
-                    3 => tester.judge::<queries::SearchForward<_, u32, P>>(),
-                    4 => tester.judge::<queries::SearchBackward<_, u32, P>>(),
+                    2..=7 => tester.mutate::<queries::RangeApply<_>>(),
+                    8 => tester.judge::<queries::SearchForward<_, u32, P>>(),
+                    9 => tester.judge::<queries::SearchBackward<_, u32, P>>(),
                     _ => unreachable!(),
                 }
             }

--- a/crates/algolib/lazy_segtree/src/lib.rs
+++ b/crates/algolib/lazy_segtree/src/lib.rs
@@ -246,11 +246,13 @@ mod tests {
         for _ in 0..4 {
             tester.initialize();
             for _ in 0..100 {
-                let command = tester.rng_mut().gen_range(0, 3);
+                let command = tester.rng_mut().gen_range(0, 5);
                 match command {
                     0 => tester.mutate::<queries::Set<_>>(),
                     1 => tester.compare::<queries::Fold<_>>(),
                     2 => tester.mutate::<queries::RangeApply<_>>(),
+                    3 => tester.judge::<queries::SearchForward<_, u32, P>>(),
+                    4 => tester.judge::<queries::SearchBackward<_, u32, P>>(),
                     _ => unreachable!(),
                 }
             }

--- a/crates/algolib/lazy_segtree/src/tests/impl_query.rs
+++ b/crates/algolib/lazy_segtree/src/tests/impl_query.rs
@@ -15,6 +15,15 @@ where
     }
 }
 
+impl<A, T> solve::Solve<queries::Get<T::Value>> for LazySegtree<A, T>
+where
+    A: Action<Point = T::Value> + Identity,
+    T: Identity,
+{
+    fn solve(&self, i: usize) -> T::Value {
+        self.get(i)
+    }
+}
 impl<A, T> solve::Mutate<queries::Set<T::Value>> for LazySegtree<A, T>
 where
     A: Action<Point = T::Value> + Identity,

--- a/crates/test_tools/queries2/src/lib.rs
+++ b/crates/test_tools/queries2/src/lib.rs
@@ -2,6 +2,9 @@ use alg_traits::Assoc;
 use query_test::Query;
 use std::{marker::PhantomData, ops::Range};
 
+#[query_test::query(fn(usize) -> T)]
+pub struct Get<T>(PhantomData<T>);
+
 #[query_test::query(fn(usize, T))]
 pub struct Set<T>(PhantomData<T>);
 

--- a/crates/test_tools/test_vector2/src/lib.rs
+++ b/crates/test_tools/test_vector2/src/lib.rs
@@ -9,6 +9,12 @@ use std::ops::Range;
 #[derive(Debug, Clone, PartialEq)]
 pub struct Vector<T: Identity>(pub Vec<T::Value>);
 
+impl<T: Identity> solve::Solve<queries::Get<T::Value>> for Vector<T> {
+    fn solve(&self, i: usize) -> T::Value {
+        self.0[i].clone()
+    }
+}
+
 impl<T: Identity> solve::Mutate<queries::Set<T::Value>> for Vector<T> {
     fn mutate(&mut self, (i, x): (usize, T::Value)) {
         self.0[i] = x;
@@ -109,6 +115,12 @@ impl<T: Identity> Vector<T> {
             std::mem::swap(&mut u, &mut v);
         }
         u..v
+    }
+}
+
+impl<T: Identity, G: GenValue<T::Value>> Gen<queries::Get<T::Value>, G> for Vector<T> {
+    fn gen(&self, rng: &mut impl Rng) -> usize {
+        self.gen_index(rng)
     }
 }
 


### PR DESCRIPTION
### Related PRs

#65 の続きです。

# Description

lazy_segtree に二分探索、要素アクセスを追加します。

テストのクエリ回数を増やし、apply_range の割合を増やしました。