### PR TITLE
Add randtools

### DIFF
--- a/crates/utils/randtools/Cargo.toml
+++ b/crates/utils/randtools/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "randtools"
+version = "0.1.0"
+authors = ["ngtkana <ngtkana@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rand = "0.7.3"
+test-case = "1.0.0"

--- a/crates/utils/randtools/src/algo.rs
+++ b/crates/utils/randtools/src/algo.rs
@@ -1,0 +1,36 @@
+use std::{cmp::Reverse, collections::BinaryHeap, iter};
+
+pub fn prufer2tree(prufer: &[usize]) -> Vec<Vec<usize>> {
+    let n = prufer.len() + 2;
+    assert!(prufer.iter().all(|&x| x < n));
+
+    let b = prufer
+        .iter()
+        .copied()
+        .chain(iter::once(n - 1))
+        .collect::<Vec<_>>();
+    let mut m = vec![0; n];
+    b.iter().for_each(|&y| m[y] += 1);
+
+    let mut heap = m
+        .iter()
+        .enumerate()
+        .filter(|&(_, &x)| x == 0)
+        .map(|(i, _)| Reverse(i))
+        .collect::<BinaryHeap<_>>();
+    let mut a = Vec::new();
+    for &y in &b {
+        a.push(heap.pop().unwrap().0);
+        m[y] -= 1;
+        if m[y] == 0 {
+            heap.push(Reverse(y));
+        }
+    }
+
+    let mut g = vec![Vec::new(); n];
+    a.iter().zip(b.iter()).for_each(|(&x, &y)| {
+        g[x].push(y);
+        g[y].push(x);
+    });
+    g
+}

--- a/crates/utils/randtools/src/lib.rs
+++ b/crates/utils/randtools/src/lib.rs
@@ -1,0 +1,39 @@
+mod algo;
+
+use rand::prelude::*;
+use std::iter;
+
+#[derive(Debug)]
+pub struct Tree(usize);
+impl Distribution<Vec<Vec<usize>>> for Tree {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec<Vec<usize>> {
+        let n = self.0;
+        assert!(1 <= n);
+        if n == 1 {
+            vec![Vec::new()]
+        } else {
+            let prufer = iter::repeat_with(|| rng.gen_range(0, n))
+                .take(n - 2)
+                .collect::<Vec<_>>();
+            algo::prufer2tree(&prufer)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Tree;
+    use rand::prelude::*;
+    mod algo;
+
+    #[test]
+    fn test_tree() {
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..20 {
+            let n = rng.gen_range(1, 1_000);
+            let g = rng.sample(Tree(n));
+            println!("g = {:?}", &g);
+            assert!(algo::is_tree(&g));
+        }
+    }
+}

--- a/crates/utils/randtools/src/tests/algo.rs
+++ b/crates/utils/randtools/src/tests/algo.rs
@@ -1,0 +1,22 @@
+use std::mem;
+
+pub fn is_tree(g: &[Vec<usize>]) -> bool {
+    // 頂点数 n, 辺数 2n - 2, 頂点番号 < n
+    let n = g.len();
+    if g.iter().map(|v| v.len()).sum::<usize>() != 2 * n - 2 || g.iter().flatten().any(|&x| n <= x)
+    {
+        return false;
+    }
+    // 連結
+    let mut stack = vec![0];
+    let mut ckd = vec![false; n];
+    ckd[0] = true;
+    while let Some(x) = stack.pop() {
+        for &y in &g[x] {
+            if !mem::replace(&mut ckd[y], true) {
+                stack.push(y);
+            }
+        }
+    }
+    ckd.iter().all(|&b| b)
+}


### PR DESCRIPTION
### Description

新しいクレート `randtools` を追加します。

### What is `randtools`

[rand](https://docs.rs/rand/0.7.3/rand/index.html) さんの [`Distribution`](https://docs.rs/rand/0.7.3/rand/distributions/trait.Distribution.html) トレイトを実装する型をもりもり入れていきます。今は `Tree` だけを追加しました。
