### PR TITLE
Rust 1.51 のリント適用と CI のリント強化

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,20 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Clippy
-      run: cargo clippy --all-targets -- -W clippy::all
+      run: |
+        cargo clippy --all-targets -- -W clippy::pedantic \
+        -A clippy::must_use_candidate \
+        -A clippy::non_ascii_literal \
+        -A clippy::cast-sign-loss \
+        -A clippy::doc_markdown \
+        -A clippy::missing_panics_doc \
+        -A clippy::cast_possible_wrap \
+        -A clippy::cast_possible_truncation \
+        -A clippy::cast_precision_loss \
+        -A clippy::module_name_repetitions \
+        -A clippy::shadow_unrelated \
+        -A clippy::maybe_infinite_iter \
+        -A clippy::similar_names
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Clippy
       run: |
         cargo clippy --all-targets -- \
+        -D warnings \
         -W clippy::pedantic \
         -W clippy::nursery \
         -A clippy::must_use_candidate \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Clippy
       run: |
         cargo clippy --all-targets -- \
-        -D warnings \
         -W clippy::pedantic \
         -W clippy::nursery \
         -A clippy::must_use_candidate \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,8 @@ jobs:
         -A clippy::maybe_infinite_iter \
         -A clippy::filter_map \
         -A clippy::similar_names \
-        -A clippy::missing_const_for_fn
+        -A clippy::missing_const_for_fn \
+        -A clippy::use_self \
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,6 @@ jobs:
         -A clippy::non_ascii_literal \
         -A clippy::cast-sign-loss \
         -A clippy::doc_markdown \
-        -A clippy::missing_panics_doc \
         -A clippy::cast_possible_wrap \
         -A clippy::cast_possible_truncation \
         -A clippy::cast_precision_loss \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clippy
       run: |
-        cargo clippy --all-targets -- -W clippy::pedantic \
+        cargo clippy --all-targets -- \
+        -W clippy::pedantic \
+        -W clippy::nursery \
         -A clippy::must_use_candidate \
         -A clippy::non_ascii_literal \
         -A clippy::cast-sign-loss \
@@ -35,7 +37,8 @@ jobs:
         -A clippy::shadow_unrelated \
         -A clippy::maybe_infinite_iter \
         -A clippy::filter_map \
-        -A clippy::similar_names
+        -A clippy::similar_names \
+        -A clippy::missing_const_fn
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Clippy
-      run: cargo clippy --all-targets
+      run: cargo clippy --all-targets -- -W clippy::all
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,17 +28,17 @@ jobs:
         -W clippy::nursery \
         -A clippy::must_use_candidate \
         -A clippy::non_ascii_literal \
-        -A clippy::cast-sign-loss \
-        -A clippy::doc_markdown \
+        -A clippy::cast_sign_loss \
         -A clippy::cast_possible_wrap \
         -A clippy::cast_possible_truncation \
         -A clippy::cast_precision_loss \
+        -A clippy::doc_markdown \
         -A clippy::module_name_repetitions \
         -A clippy::shadow_unrelated \
         -A clippy::maybe_infinite_iter \
         -A clippy::filter_map \
         -A clippy::similar_names \
-        -A clippy::missing_const_fn
+        -A clippy::missing_const_for_fn
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,7 @@ jobs:
         -A clippy::module_name_repetitions \
         -A clippy::shadow_unrelated \
         -A clippy::maybe_infinite_iter \
+        -A clippy::filter_map \
         -A clippy::similar_names
 
   test:

--- a/crates/algolib/bfs/src/lib.rs
+++ b/crates/algolib/bfs/src/lib.rs
@@ -131,9 +131,7 @@ mod tests {
         assert_eq!(dist[start], 0);
         for (u, v) in g
             .iter()
-            .enumerate()
-            .map(|(i, v)| v.iter().map(move |&j| (i, j)))
-            .flatten()
+            .enumerate().flat_map(|(i, v)| v.iter().map(move |&j| (i, j)))
         {
             assert!(dist[u] == dist[v] || dist[u] + 1 == dist[v] || dist[u] == dist[v] + 1);
         }
@@ -173,9 +171,7 @@ mod tests {
             assert_eq!(path.len(), diam as usize + 1);
             let edges = g
                 .iter()
-                .enumerate()
-                .map(|(i, v)| v.iter().map(move |&j| (i, j)))
-                .flatten()
+                .enumerate().flat_map(|(i, v)| v.iter().map(move |&j| (i, j)))
                 .collect::<HashSet<_>>();
             accum::for_each(&path, |&u, &v| assert!(edges.contains(&(u, v))));
         }
@@ -186,9 +182,7 @@ mod tests {
         let mut dist = vec![vec![std::u32::MAX; n]; n];
         (0..n).for_each(|i| dist[i][i] = 0);
         g.iter()
-            .enumerate()
-            .map(|(i, v)| v.iter().copied().map(move |j| (i, j)))
-            .flatten()
+            .enumerate().flat_map(|(i, v)| v.iter().copied().map(move |j| (i, j)))
             .for_each(|(i, j)| {
                 dist[i][j] = 1;
                 dist[j][i] = 1
@@ -203,9 +197,7 @@ mod tests {
         }
         assert!(dist.iter().flatten().all(|&x| x != u32::MAX));
         dist.iter()
-            .enumerate()
-            .map(|(i, v)| v.iter().copied().enumerate().map(move |(j, x)| (i, j, x)))
-            .flatten()
+            .enumerate().flat_map(|(i, v)| v.iter().copied().enumerate().map(move |(j, x)| (i, j, x)))
             .map(|(i, j, x)| ([i, j], x))
             .max_by_key(|&(_, x)| x)
             .unwrap()

--- a/crates/algolib/bfs/src/lib.rs
+++ b/crates/algolib/bfs/src/lib.rs
@@ -3,10 +3,10 @@ use std::collections::VecDeque;
 /// 木の直径を一つ探し、その両端点とその間の距離を返します。
 pub fn tree_diamter(g: &[Vec<usize>]) -> ([usize; 2], u32) {
     assert_eq!(g.iter().flatten().count(), (g.len() - 1) * 2);
-    let dist = calc_dist(0, &g);
+    let dist = calc_dist(0, g);
     let &diam = dist.iter().max().unwrap();
     let x = dist.iter().position(|&d| d == diam).unwrap();
-    let dist = calc_dist(x, &g);
+    let dist = calc_dist(x, g);
     let &diam = dist.iter().max().unwrap();
     let y = dist.iter().position(|&d| d == diam).unwrap();
     ([x, y], diam)
@@ -15,10 +15,10 @@ pub fn tree_diamter(g: &[Vec<usize>]) -> ([usize; 2], u32) {
 /// 木の直径を一つ探し、頂点列とパスの長さ（辺の個数）を返します。
 pub fn tree_diamter_restore(g: &[Vec<usize>]) -> (Vec<usize>, u32) {
     assert_eq!(g.iter().flatten().count(), (g.len() - 1) * 2);
-    let dist = calc_dist(0, &g);
+    let dist = calc_dist(0, g);
     let &diam = dist.iter().max().unwrap();
     let x = dist.iter().position(|&d| d == diam).unwrap();
-    let (dist, prv) = calc_dist_restore(x, &g);
+    let (dist, prv) = calc_dist_restore(x, g);
     let &diam = dist.iter().max().unwrap();
     let mut res = vec![dist.iter().position(|&d| d == diam).unwrap()];
     loop {
@@ -68,7 +68,7 @@ pub fn calc_dist_restore(start: usize, g: &[Vec<usize>]) -> (Vec<u32>, Vec<usize
 
 /// start から end が到達可能ならば最短経路の頂点列を返し、不能ならば `None` を返します。
 pub fn find_path(start: usize, end: usize, g: &[Vec<usize>]) -> Option<Vec<usize>> {
-    let (dist, prv) = calc_dist_restore(start, &g);
+    let (dist, prv) = calc_dist_restore(start, g);
     if dist[end] == std::u32::MAX {
         None
     } else {

--- a/crates/algolib/bfs01/src/lib.rs
+++ b/crates/algolib/bfs01/src/lib.rs
@@ -108,9 +108,7 @@ mod tests {
         assert_eq!(dist[s], 0);
         for (u, v, w) in g
             .iter()
-            .enumerate()
-            .map(|(i, v)| v.iter().map(move |&(j, w)| (i, j, w)))
-            .flatten()
+            .enumerate().flat_map(|(i, v)| v.iter().map(move |&(j, w)| (i, j, w)))
         {
             match w {
                 super::Weight::Zero => {

--- a/crates/algolib/dfs/src/lib.rs
+++ b/crates/algolib/dfs/src/lib.rs
@@ -37,9 +37,7 @@ mod tests {
             // calc_reachability
             let ckd = calc_reachability(s, &g);
             g.iter()
-                .enumerate()
-                .map(|(i, v)| v.iter().map(move |&j| (i, j)))
-                .flatten()
+                .enumerate().flat_map(|(i, v)| v.iter().map(move |&j| (i, j)))
                 .for_each(|(i, j)| assert_eq!(ckd[i], ckd[j]));
         }
     }

--- a/crates/algolib/dial/src/lib.rs
+++ b/crates/algolib/dial/src/lib.rs
@@ -97,9 +97,7 @@ mod tests {
             dbg::lg!(&dist, &prv);
             let edges = g
                 .iter()
-                .enumerate()
-                .map(|(i, v)| v.iter().map(move |&(j, w)| ((i, j), w)))
-                .flatten()
+                .enumerate().flat_map(|(i, v)| v.iter().map(move |&(j, w)| ((i, j), w)))
                 .collect::<HashMap<_, _>>();
             dbg::lg!(&edges);
             validate_dist_prv(&prv, &dist, &edges);
@@ -110,9 +108,7 @@ mod tests {
         assert_eq!(dist[s], 0);
         for (u, v, w) in g
             .iter()
-            .enumerate()
-            .map(|(i, v)| v.iter().map(move |&(j, w)| (i, j, w)))
-            .flatten()
+            .enumerate().flat_map(|(i, v)| v.iter().map(move |&(j, w)| (i, j, w)))
         {
             assert!(dist[u].saturating_add(w) >= dist[v]);
         }

--- a/crates/algolib/dijkstra_radix_heap/src/lib.rs
+++ b/crates/algolib/dijkstra_radix_heap/src/lib.rs
@@ -83,9 +83,7 @@ mod tests {
             dbg::lg!(&dist, &prv);
             let edges = g
                 .iter()
-                .enumerate()
-                .map(|(i, v)| v.iter().map(move |&(j, w)| ((i, j), w)))
-                .flatten()
+                .enumerate().flat_map(|(i, v)| v.iter().map(move |&(j, w)| ((i, j), w)))
                 .collect::<HashMap<_, _>>();
             dbg::lg!(&edges);
             validate_dist_prv(&prv, &dist, &edges);
@@ -96,9 +94,7 @@ mod tests {
         assert_eq!(dist[s], 0);
         for (u, v, w) in g
             .iter()
-            .enumerate()
-            .map(|(i, v)| v.iter().map(move |&(j, w)| (i, j, w)))
-            .flatten()
+            .enumerate().flat_map(|(i, v)| v.iter().map(move |&(j, w)| (i, j, w)))
         {
             assert!(dist[u].saturating_add(w) >= dist[v]);
         }

--- a/crates/algolib/hld/src/lib.rs
+++ b/crates/algolib/hld/src/lib.rs
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn test_singleton() {
         let g = vec![Vec::new()];
-        let _ = Hld::new(g, 0);
+        Hld::new(g, 0);
     }
 
     #[test]

--- a/crates/algolib/hld/src/lib.rs
+++ b/crates/algolib/hld/src/lib.rs
@@ -50,7 +50,14 @@ impl Hld {
         let mut ord = Vec::new();
         let mut vid = vec![std::usize::MAX; n];
         efs(root, &mut head, &mut ord, &mut vid, &g);
-        Self { root, g, head, parent, ord, vid }
+        Self {
+            root,
+            g,
+            head,
+            parent,
+            ord,
+            vid,
+        }
     }
     pub fn lca(&self, u: usize, v: usize) -> usize {
         self.ord[self.iter_vtx(u, v).last().unwrap().0]
@@ -92,16 +99,16 @@ impl<'a> Iterator for Iter<'a> {
             if self.hld.vid[self.u] > self.hld.vid[self.v] {
                 std::mem::swap(&mut self.u, &mut self.v);
             }
-            let res = if self.hld.head[self.u] != self.hld.head[self.v] {
-                let res = (self.hld.vid[self.hld.head[self.v]], self.hld.vid[self.v]);
-                self.v = self.hld.parent[self.hld.head[self.v]];
-                res
-            } else {
+            let res = if self.hld.head[self.u] == self.hld.head[self.v] {
                 self.finished = true;
                 match self.include_lca {
                     IncludeLca::Yes => (self.hld.vid[self.u], self.hld.vid[self.v]),
                     IncludeLca::No => (self.hld.vid[self.u] + 1, self.hld.vid[self.v]),
                 }
+            } else {
+                let res = (self.hld.vid[self.hld.head[self.v]], self.hld.vid[self.v]);
+                self.v = self.hld.parent[self.hld.head[self.v]];
+                res
             };
             Some(res)
         }

--- a/crates/algolib/hld/src/lib.rs
+++ b/crates/algolib/hld/src/lib.rs
@@ -11,8 +11,6 @@ pub struct Hld {
 }
 impl Hld {
     pub fn new(mut g: Vec<Vec<usize>>, root: usize) -> Self {
-        let n = g.len();
-
         fn dfs(x: usize, p: usize, parent: &mut [usize], size: &mut [u32], g: &mut [Vec<usize>]) {
             let mut child = g[x].iter().copied().filter(|&y| y != p).collect::<Vec<_>>();
             for &c in &child {
@@ -27,11 +25,6 @@ impl Hld {
             }
             g[x] = child
         }
-        let mut size = vec![1; n];
-        let mut parent = vec![std::usize::MAX; n];
-        parent[root] = root;
-        dfs(root, root, &mut parent, &mut size, &mut g);
-
         fn efs(
             x: usize,
             head: &mut [usize],
@@ -46,6 +39,13 @@ impl Hld {
             }
             g[x].iter().for_each(|&y| efs(y, head, ord, vid, g));
         }
+
+        let n = g.len();
+        let mut size = vec![1; n];
+        let mut parent = vec![std::usize::MAX; n];
+        parent[root] = root;
+        dfs(root, root, &mut parent, &mut size, &mut g);
+
         let mut head = (0..n).collect::<Vec<_>>();
         let mut ord = Vec::new();
         let mut vid = vec![std::usize::MAX; n];
@@ -181,12 +181,14 @@ mod tests {
     }
 
     fn psp_path_unsorted(hld: &Hld, s: usize, t: usize) -> Vec<usize> {
-        hld.iter_vtx(s, t).flat_map(|(l, r)| (l..=r).map(|i| hld.ord[i]))
+        hld.iter_vtx(s, t)
+            .flat_map(|(l, r)| (l..=r).map(|i| hld.ord[i]))
             .collect()
     }
 
     fn psp_path_unsorted_without_lca(hld: &Hld, s: usize, t: usize) -> Vec<usize> {
-        hld.iter_edge(s, t).flat_map(|(l, r)| (l..=r).map(|i| hld.ord[i]))
+        hld.iter_edge(s, t)
+            .flat_map(|(l, r)| (l..=r).map(|i| hld.ord[i]))
             .collect()
     }
 

--- a/crates/algolib/hld/src/lib.rs
+++ b/crates/algolib/hld/src/lib.rs
@@ -197,8 +197,8 @@ mod tests {
     }
 
     fn lca_brute(g: &[Vec<usize>], u: usize, v: usize, root: usize) -> usize {
-        let path_a = bfs::find_path(root, u, &g).unwrap();
-        let path_b = bfs::find_path(root, v, &g).unwrap();
+        let path_a = bfs::find_path(root, u, g).unwrap();
+        let path_b = bfs::find_path(root, v, g).unwrap();
         path_a
             .into_iter()
             .zip(path_b.into_iter())

--- a/crates/algolib/hld/src/lib.rs
+++ b/crates/algolib/hld/src/lib.rs
@@ -181,16 +181,12 @@ mod tests {
     }
 
     fn psp_path_unsorted(hld: &Hld, s: usize, t: usize) -> Vec<usize> {
-        hld.iter_vtx(s, t)
-            .map(|(l, r)| (l..=r).map(|i| hld.ord[i]))
-            .flatten()
+        hld.iter_vtx(s, t).flat_map(|(l, r)| (l..=r).map(|i| hld.ord[i]))
             .collect()
     }
 
     fn psp_path_unsorted_without_lca(hld: &Hld, s: usize, t: usize) -> Vec<usize> {
-        hld.iter_edge(s, t)
-            .map(|(l, r)| (l..=r).map(|i| hld.ord[i]))
-            .flatten()
+        hld.iter_edge(s, t).flat_map(|(l, r)| (l..=r).map(|i| hld.ord[i]))
             .collect()
     }
 

--- a/crates/algolib/hld/src/lib.rs
+++ b/crates/algolib/hld/src/lib.rs
@@ -50,14 +50,7 @@ impl Hld {
         let mut ord = Vec::new();
         let mut vid = vec![std::usize::MAX; n];
         efs(root, &mut head, &mut ord, &mut vid, &g);
-        Self {
-            root,
-            g,
-            head,
-            ord,
-            vid,
-            parent,
-        }
+        Self { root, g, head, parent, ord, vid }
     }
     pub fn lca(&self, u: usize, v: usize) -> usize {
         self.ord[self.iter_vtx(u, v).last().unwrap().0]

--- a/crates/algolib/inversion_number/src/lib.rs
+++ b/crates/algolib/inversion_number/src/lib.rs
@@ -18,7 +18,7 @@
 /// ```
 ///
 pub fn inversion_number(value_limit: usize, a: &[usize]) -> u64 {
-    let mut inv = 0u64;
+    let mut inv = 0_u64;
     let mut used = vec![0; value_limit + 1];
     for (i, &x) in a.iter().enumerate() {
         inv += i as u64;

--- a/crates/algolib/inversion_number/src/lib.rs
+++ b/crates/algolib/inversion_number/src/lib.rs
@@ -44,13 +44,13 @@ pub fn inversion_number(value_limit: usize, a: &[usize]) -> u64 {
 mod tests {
     use {super::inversion_number, test_case::test_case};
 
-    #[test_case(3, vec![0, 1, 2] => 0)]
-    #[test_case(3, vec![0, 2, 1] => 1)]
-    #[test_case(3, vec![1, 0, 2] => 1)]
-    #[test_case(3, vec![1, 2, 0] => 2)]
-    #[test_case(3, vec![2, 0, 1] => 2)]
-    #[test_case(3, vec![2, 1, 0] => 3)]
-    fn test_hand(n: usize, a: Vec<usize>) -> u64 {
+    #[test_case(3, &[0, 1, 2] => 0)]
+    #[test_case(3, &[0, 2, 1] => 1)]
+    #[test_case(3, &[1, 0, 2] => 1)]
+    #[test_case(3, &[1, 2, 0] => 2)]
+    #[test_case(3, &[2, 0, 1] => 2)]
+    #[test_case(3, &[2, 1, 0] => 3)]
+    fn test_hand(n: usize, a: &[usize]) -> u64 {
         inversion_number(n, &a)
     }
 }

--- a/crates/algolib/inversion_number/src/lib.rs
+++ b/crates/algolib/inversion_number/src/lib.rs
@@ -51,6 +51,6 @@ mod tests {
     #[test_case(3, &[2, 0, 1] => 2)]
     #[test_case(3, &[2, 1, 0] => 3)]
     fn test_hand(n: usize, a: &[usize]) -> u64 {
-        inversion_number(n, &a)
+        inversion_number(n, a)
     }
 }

--- a/crates/algolib/scc/src/lib.rs
+++ b/crates/algolib/scc/src/lib.rs
@@ -133,7 +133,7 @@ impl TwoSat {
             .1
             .chunks_exact(2)
             .map(|v| {
-                use cmp::Ordering::*;
+                use cmp::Ordering::{Equal, Greater, Less};
                 match v[0].cmp(&v[1]) {
                     Equal => None,
                     Less => Some(true),

--- a/crates/algolib/scc/src/traversal.rs
+++ b/crates/algolib/scc/src/traversal.rs
@@ -8,7 +8,7 @@ pub struct Traversal {
 }
 
 impl Traversal {
-    pub fn pre_order(graph: &[Vec<usize>]) -> Traversal {
+    pub fn pre_order(graph: &[Vec<usize>]) -> Self {
         fn dfs(x: usize, graph: &[Vec<usize>], res: &mut PermutationBuilder) {
             res.visit(x);
             for &y in &graph[x] {
@@ -21,13 +21,13 @@ impl Traversal {
         let mut res = PermutationBuilder::new(graph.len());
         for i in 0..graph.len() {
             if !res.on_stack(i) {
-                dfs(i, &graph, &mut res);
+                dfs(i, graph, &mut res);
             }
         }
         res.build()
     }
 
-    pub fn post_order(graph: &[Vec<usize>]) -> Traversal {
+    pub fn post_order(graph: &[Vec<usize>]) -> Self {
         fn dfs(x: usize, graph: &[Vec<usize>], ckd: &mut [bool], res: &mut PermutationBuilder) {
             for &y in &graph[x] {
                 if !mem::replace(&mut ckd[y], true) {
@@ -42,7 +42,7 @@ impl Traversal {
         let mut res = PermutationBuilder::new(graph.len());
         for i in 0..graph.len() {
             if !mem::replace(&mut ckd[i], true) {
-                dfs(i, &graph, &mut ckd, &mut res);
+                dfs(i, graph, &mut ckd, &mut res);
             }
         }
         res.build()

--- a/crates/algolib/suffix_array/src/lib.rs
+++ b/crates/algolib/suffix_array/src/lib.rs
@@ -80,7 +80,7 @@ pub fn lcp_array<T: Ord>(s: &[T], sa: &[usize]) -> Vec<usize> {
     assert!(!sa.is_empty());
 
     let n = s.len();
-    let rnk = make_rank(&sa);
+    let rnk = make_rank(sa);
     let mut h = 0usize;
     let mut lcp = vec![0; n - 1];
     for (i, &r) in rnk.iter().enumerate() {

--- a/crates/algolib/suffix_array/src/lib.rs
+++ b/crates/algolib/suffix_array/src/lib.rs
@@ -81,7 +81,7 @@ pub fn lcp_array<T: Ord>(s: &[T], sa: &[usize]) -> Vec<usize> {
 
     let n = s.len();
     let rnk = make_rank(sa);
-    let mut h = 0usize;
+    let mut h = 0_usize;
     let mut lcp = vec![0; n - 1];
     for (i, &r) in rnk.iter().enumerate() {
         h = h.saturating_sub(1);

--- a/crates/algolib/suffix_array/src/lib.rs
+++ b/crates/algolib/suffix_array/src/lib.rs
@@ -49,17 +49,14 @@ pub fn suffix_array<T: Ord>(s: &[T]) -> Vec<usize> {
         for i in 1..n {
             let l = ord_swp[i - 1];
             let r = ord_swp[i];
-            cmp_swp[i] = if (
-                cmp[ord_inverse[l]],
-                ord_inverse.get(l + d).map(|&ld| cmp[ld]).unwrap_or(n),
-            ) == (
-                cmp[ord_inverse[r]],
-                ord_inverse.get(r + d).map(|&rd| cmp[rd]).unwrap_or(n),
-            ) {
+            cmp_swp[i] = if cmp[ord_inverse[l]] == cmp[ord_inverse[r]]
+                && ord_inverse.get(l + d).map_or(n, |&ld| cmp[ld])
+                    == ord_inverse.get(r + d).map_or(n, |&rd| cmp[rd])
+            {
                 cmp_swp[i - 1]
             } else {
                 cmp_swp[i - 1] + 1
-            }
+            };
         }
 
         ord = ord_swp;

--- a/crates/algolib/vec_lines/src/lib.rs
+++ b/crates/algolib/vec_lines/src/lib.rs
@@ -303,7 +303,7 @@ fn weakly_convex<T: Signed>(
 }
 
 fn golden_section([i0, i3]: [isize; 2]) -> [isize; 2] {
-    let d = ((i3 - i0) as f64 * (5f64.sqrt() - 1.0) / 2.0).ceil() as isize;
+    let d = ((i3 - i0) as f64 * (5_f64.sqrt() - 1.0) / 2.0).ceil() as isize;
     [i3 - d, i0 + d]
 }
 

--- a/crates/algolib/zeta/src/lib.rs
+++ b/crates/algolib/zeta/src/lib.rs
@@ -211,6 +211,7 @@ mod tests {
         test_case::test_case,
     };
 
+    #[derive(Clone, Copy)]
     enum Dir {
         Sub,
         Super,

--- a/crates/disjoint_set/partially_persistent_union_find/src/lib.rs
+++ b/crates/disjoint_set/partially_persistent_union_find/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
                     // size
                     2 => {
                         let u = rng.gen_range(0..n);
-                        let t = rng.gen_range(0..history.len() + 1);
+                        let t = rng.gen_range(0..=history.len());
                         let result = uf.size(u, t);
                         let cmp = retake(n, t, &history);
                         let expected = cmp.iter().filter(|&&c| c == cmp[u]).count();

--- a/crates/flow/dinic/src/lib.rs
+++ b/crates/flow/dinic/src/lib.rs
@@ -815,7 +815,7 @@ mod tests {
                 (
                     rng.gen_range(0..n),
                     rng.gen_range(0..n),
-                    rng.gen_range(0..1u32 << 16),
+                    rng.gen_range(0..1_u32 << 16),
                 )
             })
             .take(m)

--- a/crates/flow/dinic/src/lib.rs
+++ b/crates/flow/dinic/src/lib.rs
@@ -872,13 +872,13 @@ mod tests {
             flow,
         } in edge_keys.iter().map(|&edge| dinic.get_edge(edge))
         {
-            excess[from] -= flow as i64;
-            excess[to] += flow as i64;
+            excess[from] -= i64::from(flow);
+            excess[to] += i64::from(flow);
             assert!(flow <= cap);
         }
         let mut excess_expected = vec![0; n];
-        excess_expected[s] -= flow as i64;
-        excess_expected[t] += flow as i64;
+        excess_expected[s] -= i64::from(flow);
+        excess_expected[t] += i64::from(flow);
         assert_eq!(excess, excess_expected);
 
         // max-flow min-cut theorem

--- a/crates/flow/gco/src/lib.rs
+++ b/crates/flow/gco/src/lib.rs
@@ -121,7 +121,7 @@ impl Gco {
         self.binary.push(Binary { ij, cost });
     }
     pub fn solve(&self) -> GcoResult {
-        solve(&self)
+        solve(self)
     }
 }
 

--- a/crates/flow/gco/src/lib.rs
+++ b/crates/flow/gco/src/lib.rs
@@ -68,7 +68,7 @@ impl Gco {
     pub fn new(n: usize) -> Self {
         Self {
             vars: n,
-            ..Default::default()
+            ..Self::default()
         }
     }
     /// 1 次の項を足します。
@@ -171,7 +171,8 @@ fn solve(gco: &Gco) -> GcoResult {
                 }
                 Ordering::Equal => (),
             }
-            for (i, j) in (0..2).flat_map(|i| (0..2).map(move |j| (i, j)))
+            for (i, j) in (0..2)
+                .flat_map(|i| (0..2).map(move |j| (i, j)))
                 .filter(|&(i, j)| [i, j][p] == 1)
             {
                 cost[i][j] -= d;

--- a/crates/flow/gco/src/lib.rs
+++ b/crates/flow/gco/src/lib.rs
@@ -171,9 +171,7 @@ fn solve(gco: &Gco) -> GcoResult {
                 }
                 Ordering::Equal => (),
             }
-            for (i, j) in (0..2)
-                .map(|i| (0..2).map(move |j| (i, j)))
-                .flatten()
+            for (i, j) in (0..2).flat_map(|i| (0..2).map(move |j| (i, j)))
                 .filter(|&(i, j)| [i, j][p] == 1)
             {
                 cost[i][j] -= d;

--- a/crates/flow/hopkarp/src/lib.rs
+++ b/crates/flow/hopkarp/src/lib.rs
@@ -212,9 +212,7 @@ mod tests {
             .collect::<Vec<_>>();
         let unmach_edges = graph
             .iter()
-            .enumerate()
-            .map(|(x, v)| v.iter().map(move |&y| (x, y)))
-            .flatten()
+            .enumerate().flat_map(|(x, v)| v.iter().map(move |&y| (x, y)))
             .filter(|&(x, y)| backward[y] != Some(x))
             .collect::<Vec<_>>();
 

--- a/crates/flow/hopkarp/src/lib.rs
+++ b/crates/flow/hopkarp/src/lib.rs
@@ -53,7 +53,7 @@ pub fn hopkarp(w: usize, graph: &[Vec<usize>]) -> HopkarpResult {
     let mut backward = vec![None; w].into_boxed_slice();
     let (left, right) = loop {
         let dist = bfs(graph, &forward, &backward);
-        if !dfs(&graph, &dist, &mut forward, &mut backward) {
+        if !dfs(graph, &dist, &mut forward, &mut backward) {
             break construct_minimum_cut(graph, &dist, &backward);
         }
     };

--- a/crates/flow/hopkarp/src/lib.rs
+++ b/crates/flow/hopkarp/src/lib.rs
@@ -105,11 +105,9 @@ fn dfs(
     ) -> bool {
         used[x] = true;
         for &y in &graph[x] {
-            let found = if let Some(z) = backward[y] {
+            let found = backward[y].map_or(true, |z| {
                 !used[z] && dist[x] + 1 == dist[z] && rec(z, graph, dist, used, forward, backward)
-            } else {
-                true
-            };
+            });
             if found {
                 backward[y] = Some(x);
                 forward[x] = Some(y);

--- a/crates/flow/hungarian/src/lib.rs
+++ b/crates/flow/hungarian/src/lib.rs
@@ -34,9 +34,7 @@ pub fn hungarian<T: Value>(cost_matrix: &[Vec<T>]) -> HungarianResult<T> {
     let mut left = vec![T::infinity(); h].into_boxed_slice();
     for (i, x) in cost_matrix
         .iter()
-        .enumerate()
-        .map(|(i, v)| v.iter().map(move |&x| (i, x)))
-        .flatten()
+        .enumerate().flat_map(|(i, v)| v.iter().map(move |&x| (i, x)))
     {
         if x < all_min {
             all_min = x;
@@ -277,9 +275,7 @@ mod tests {
         // feasibility
         for (i, j, x) in cost_matrix
             .iter()
-            .enumerate()
-            .map(|(i, v)| v.iter().enumerate().map(move |(j, &x)| (i, j, x)))
-            .flatten()
+            .enumerate().flat_map(|(i, v)| v.iter().enumerate().map(move |(j, &x)| (i, j, x)))
         {
             assert!(
                 right[j] <= x + left[i] + T::epsilon(),

--- a/crates/flow/hungarian/src/lib.rs
+++ b/crates/flow/hungarian/src/lib.rs
@@ -199,10 +199,10 @@ mod tests {
         test_case::test_case,
     };
 
-    #[test_case(vec![vec![4, 3, 5], vec![3, 5, 9], vec![4, 1, 4]] => (vec![2, 0, 1], 9); "yosupo sample")]
-    #[test_case(vec![vec![4, 3, 5], vec![3, 5, 0], vec![4, 1, 4]] => (vec![0, 2, 1], 5); "handmade")]
-    fn test_hand(cost_matrix: Vec<Vec<u8>>) -> (Vec<usize>, u8) {
-        let HungarianResult { forward, value, .. } = hungarian(&cost_matrix);
+    #[test_case(&[vec![4, 3, 5], vec![3, 5, 9], vec![4, 1, 4]] => (vec![2, 0, 1], 9); "yosupo sample")]
+    #[test_case(&[vec![4, 3, 5], vec![3, 5, 0], vec![4, 1, 4]] => (vec![0, 2, 1], 5); "handmade")]
+    fn test_hand(cost_matrix: &[Vec<u8>]) -> (Vec<usize>, u8) {
+        let HungarianResult { forward, value, .. } = hungarian(cost_matrix);
         (forward.into_vec(), value)
     }
 

--- a/crates/fp/fp/src/lib.rs
+++ b/crates/fp/fp/src/lib.rs
@@ -261,8 +261,8 @@ macro_rules! forward_ops {
         }
 
         impl<'a, T: Mod> $trait<&'a Fp<T>> for Fp<T> {
-            type Output = Fp<T>;
-            fn $method(self, other: &Fp<T>) -> Self::Output {
+            type Output = Self;
+            fn $method(self, other: &Self) -> Self::Output {
                 $trait::$method(self, *other)
             }
         }
@@ -455,7 +455,8 @@ mod tests {
             let x = rng.gen_range(0..=std::u32::MAX);
             let y = rng.gen_range(0..=std::u32::MAX);
             let z = rng.gen_range(0..=std::u32::MAX);
-            let expected = ((u128::from(x) * u128::from(y) * u128::from(z)) % u128::from(Fp::P)) as u32;
+            let expected =
+                ((u128::from(x) * u128::from(y) * u128::from(z)) % u128::from(Fp::P)) as u32;
             let result = [Fp::new(x), Fp::new(y), Fp::new(z)]
                 .iter()
                 .product::<Fp>()

--- a/crates/fp/fp/src/lib.rs
+++ b/crates/fp/fp/src/lib.rs
@@ -98,7 +98,7 @@ impl<M: Mod> Fp<M> {
     pub const P: u32 = M::P;
     /// 新しく構築します。
     pub fn new(value: u32) -> Self {
-        Fp::from_raw(reduce::<M>(value as u64 * M::R2 as u64))
+        Self::from_raw(reduce::<M>(value as u64 * M::R2 as u64))
     }
     /// オブジェクトの表す整数を返します。
     pub fn value(self) -> u32 {
@@ -112,7 +112,7 @@ impl<M: Mod> Fp<M> {
     /// 逆数を返します。
     #[allow(clippy::many_single_char_names)]
     pub fn recip(self) -> Self {
-        assert_ne!(self, Fp::new(0), "0 はだめ。");
+        assert_ne!(self, Self::new(0), "0 はだめ。");
         let mut x = M::P as i32;
         let mut y = self.value() as i32;
         let mut u = 0;
@@ -135,10 +135,10 @@ impl<M: Mod> Fp<M> {
     pub fn pow<T: Into<u64>>(self, exp: T) -> Self {
         let mut exp = exp.into();
         if exp == 0 {
-            return Fp::new(1);
+            return Self::new(1);
         }
         let mut base = self;
-        let mut acc = Fp::new(1);
+        let mut acc = Self::new(1);
         while 1 < exp {
             if exp & 1 == 1 {
                 acc *= base;
@@ -215,7 +215,7 @@ impl<M: Mod> Hash for Fp<M> {
         self.value().hash(state);
     }
 }
-impl<M: Mod, T: Into<Fp<M>>> AddAssign<T> for Fp<M> {
+impl<M: Mod, T: Into<Self>> AddAssign<T> for Fp<M> {
     fn add_assign(&mut self, rhs: T) {
         self.value += rhs.into().value;
         if M::P * 2 <= self.value {
@@ -223,7 +223,7 @@ impl<M: Mod, T: Into<Fp<M>>> AddAssign<T> for Fp<M> {
         }
     }
 }
-impl<M: Mod, T: Into<Fp<M>>> SubAssign<T> for Fp<M> {
+impl<M: Mod, T: Into<Self>> SubAssign<T> for Fp<M> {
     fn sub_assign(&mut self, rhs: T) {
         let rhs = rhs.into();
         if self.value < rhs.value {
@@ -232,13 +232,13 @@ impl<M: Mod, T: Into<Fp<M>>> SubAssign<T> for Fp<M> {
         self.value -= rhs.value;
     }
 }
-impl<M: Mod, T: Into<Fp<M>>> MulAssign<T> for Fp<M> {
+impl<M: Mod, T: Into<Self>> MulAssign<T> for Fp<M> {
     fn mul_assign(&mut self, rhs: T) {
         self.value = reduce::<M>(self.value as u64 * rhs.into().value as u64);
     }
 }
 #[allow(clippy::suspicious_op_assign_impl)]
-impl<M: Mod, T: Into<Fp<M>>> DivAssign<T> for Fp<M> {
+impl<M: Mod, T: Into<Self>> DivAssign<T> for Fp<M> {
     fn div_assign(&mut self, rhs: T) {
         *self *= rhs.into().recip();
     }
@@ -284,7 +284,7 @@ forward_ops! {
 impl<M: Mod> Neg for Fp<M> {
     type Output = Self;
     fn neg(self) -> Self {
-        Fp::from_raw(M::P * 2 - self.value)
+        Self::from_raw(M::P * 2 - self.value)
     }
 }
 impl<M: Mod> Sum for Fp<M> {
@@ -298,12 +298,12 @@ impl<M: Mod> Product for Fp<M> {
     }
 }
 impl<'a, M: Mod> Sum<&'a Self> for Fp<M> {
-    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Fp<M> {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::new(0), |b, x| b + x)
     }
 }
 impl<'a, M: Mod> Product<&'a Self> for Fp<M> {
-    fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Fp<M> {
+    fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::new(1), |b, x| b * x)
     }
 }

--- a/crates/fp/fp/src/lib.rs
+++ b/crates/fp/fp/src/lib.rs
@@ -46,7 +46,7 @@ pub trait Mod: Clone + Copy + Hash {
     /// -P mod 2 ^ 32（モンゴメリ乗算用）
     const K: u32;
     /// 2 ^ 64 mod P（モンゴメリ乗算用）
-    const R2: u32 = ((1u128 << 64) % Self::P as u128) as _; // 2 ^ 64 mod P
+    const R2: u32 = ((1_u128 << 64) % Self::P as u128) as _; // 2 ^ 64 mod P
 }
 fn reduce<M: Mod>(x: u64) -> u32 {
     ((x + u64::from(M::K.wrapping_mul(x as u32)) * u64::from(M::P)) >> 32) as u32
@@ -449,7 +449,7 @@ mod tests {
 
     #[test]
     fn test_product() {
-        assert_eq!(Fp::new(3).pow(4u32), Fp::new(81));
+        assert_eq!(Fp::new(3).pow(4_u32), Fp::new(81));
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..20 {
             let x = rng.gen_range(0..=std::u32::MAX);

--- a/crates/fp/fps/src/arith.rs
+++ b/crates/fp/fps/src/arith.rs
@@ -65,7 +65,7 @@ where
 /// # 制約
 ///
 /// * `a[0]` が 1 。
-pub fn fps_exp<M: Mod>(a: Vec<Fp<M>>, precision: usize) -> Vec<Fp<M>>
+pub fn fps_exp<M: Mod>(a: &[Fp<M>], precision: usize) -> Vec<Fp<M>>
 where
     Fp<M>: Convolution,
 {
@@ -215,7 +215,7 @@ mod tests {
                 .chain(repeat_with(|| Fp::new(rng.gen_range(0..20))))
                 .take(n)
                 .collect_vec();
-            let result = fps_exp(a.clone(), precision);
+            let result = fps_exp(&a, precision);
             let mut expected = vec![Fp::new(0); precision];
             expected[0] = Fp::new(1);
             let mut acc = vec![Fp::new(1)];

--- a/crates/fp/fps/src/arith.rs
+++ b/crates/fp/fps/src/arith.rs
@@ -99,7 +99,7 @@ pub fn fps_sqrt<M: Mod>(mut a: Vec<Fp<M>>, precision: usize) -> Option<Vec<Fp<M>
 where
     Fp<M>: Convolution,
 {
-    if a.as_slice() == &[Fp::new(0)] {
+    if a.as_slice() == [Fp::new(0)] {
         return Some(a);
     }
     let zeros = a

--- a/crates/fp/fps/src/fourier.rs
+++ b/crates/fp/fps/src/fourier.rs
@@ -1,11 +1,10 @@
 use super::{Fp, Mod};
 
 pub fn fourier_impl<M: Mod>(a: &mut [Fp<M>], root: &[Fp<M>]) {
-    let n = a.len();
     let mut d = a.len() / 2;
     while d != 0 {
         let mut coeff = Fp::new(1);
-        for (i, t) in (0..n).step_by(2 * d).zip(1u32..) {
+        for (i, t) in (0..a.len()).step_by(2 * d).zip(1u32..) {
             for (i, j) in (i..i + d).zip(i + d..) {
                 let x = a[i];
                 let y = a[j] * coeff;
@@ -18,11 +17,10 @@ pub fn fourier_impl<M: Mod>(a: &mut [Fp<M>], root: &[Fp<M>]) {
     }
 }
 pub fn fourier_inverse_impl<M: Mod>(a: &mut [Fp<M>], root_recip: &[Fp<M>]) {
-    let n = a.len();
     let mut d = 1;
-    while d != n {
+    while d != a.len() {
         let mut coeff = Fp::new(1);
-        for (i, t) in (0..n).step_by(2 * d).zip(1u32..) {
+        for (i, t) in (0..a.len()).step_by(2 * d).zip(1u32..) {
             for (i, j) in (i..i + d).zip(i + d..) {
                 let x = a[i];
                 let y = a[j];

--- a/crates/fp/fps/src/fourier.rs
+++ b/crates/fp/fps/src/fourier.rs
@@ -4,7 +4,7 @@ pub fn fourier_impl<M: Mod>(a: &mut [Fp<M>], root: &[Fp<M>]) {
     let mut d = a.len() / 2;
     while d != 0 {
         let mut coeff = Fp::new(1);
-        for (i, t) in (0..a.len()).step_by(2 * d).zip(1u32..) {
+        for (i, t) in (0..a.len()).step_by(2 * d).zip(1_u32..) {
             for (i, j) in (i..i + d).zip(i + d..) {
                 let x = a[i];
                 let y = a[j] * coeff;
@@ -20,7 +20,7 @@ pub fn fourier_inverse_impl<M: Mod>(a: &mut [Fp<M>], root_recip: &[Fp<M>]) {
     let mut d = 1;
     while d != a.len() {
         let mut coeff = Fp::new(1);
-        for (i, t) in (0..a.len()).step_by(2 * d).zip(1u32..) {
+        for (i, t) in (0..a.len()).step_by(2 * d).zip(1_u32..) {
             for (i, j) in (i..i + d).zip(i + d..) {
                 let x = a[i];
                 let y = a[j];

--- a/crates/fp/fps/src/lib.rs
+++ b/crates/fp/fps/src/lib.rs
@@ -154,9 +154,9 @@ pub fn integer_convolution(a: Vec<u32>, b: Vec<u32>) -> Vec<u128> {
             let x3 = ((e3 - Fp3::new(x1.value())) * Fp3::new(Fp1::P).recip()
                 - Fp3::new(x2.value()))
                 * Fp3::new(Fp2::P).recip();
-            x1.value() as u128
-                + x2.value() as u128 * Fp1::P as u128
-                + x3.value() as u128 * Fp1::P as u128 * Fp2::P as u128
+            u128::from(x1.value())
+                + u128::from(x2.value()) * u128::from(Fp1::P)
+                + u128::from(x3.value()) * u128::from(Fp1::P) * u128::from(Fp2::P)
         })
         .collect::<Vec<_>>()
 }
@@ -258,7 +258,7 @@ mod test {
             let mut expected = vec![0; n + m - 1];
             for i in 0..n {
                 for j in 0..m {
-                    expected[i + j] += a[i] as u128 * b[j] as u128;
+                    expected[i + j] += u128::from(a[i]) * u128::from(b[j]);
                 }
             }
             assert_eq!(result, expected);

--- a/crates/fp/fps/src/lib.rs
+++ b/crates/fp/fps/src/lib.rs
@@ -129,7 +129,7 @@ impl_fourier_and_convolution! {
 }
 
 /// 3 つの NTT-friendly 素数を用いて整数でコンボリューションします。
-pub fn integer_convolution(a: Vec<u32>, b: Vec<u32>) -> Vec<u128> {
+pub fn integer_convolution(a: &[u32], b: &[u32]) -> Vec<u128> {
     type Fp1 = F998244353;
     type Fp2 = F1012924417;
     type Fp3 = F924844033;
@@ -162,7 +162,7 @@ pub fn integer_convolution(a: Vec<u32>, b: Vec<u32>) -> Vec<u128> {
 }
 
 /// 3 つの NTT-friendly 素数を用いて任意 mod でコンボリューションします。
-pub fn anymod_convolution<M: Mod>(a: Vec<Fp<M>>, b: Vec<Fp<M>>) -> Vec<Fp<M>> {
+pub fn anymod_convolution<M: Mod>(a: &[Fp<M>], b: &[Fp<M>]) -> Vec<Fp<M>> {
     type Fp1 = F998244353;
     type Fp2 = F1012924417;
     type Fp3 = F924844033;
@@ -254,7 +254,7 @@ mod test {
             let b = repeat_with(|| rng.gen_range(0..std::u32::MAX))
                 .take(m)
                 .collect_vec();
-            let result = integer_convolution(a.clone(), b.clone());
+            let result = integer_convolution(&a, &b);
             let mut expected = vec![0; n + m - 1];
             for i in 0..n {
                 for j in 0..m {
@@ -278,7 +278,7 @@ mod test {
             let b = repeat_with(|| Fp::new(rng.gen_range(0..Fp::P)))
                 .take(m)
                 .collect_vec();
-            let result = anymod_convolution(a.clone(), b.clone());
+            let result = anymod_convolution(&a, &b);
             let mut expected = vec![Fp::new(0); n + m - 1];
             for i in 0..n {
                 for j in 0..m {

--- a/crates/fp/montgomery/src/lib.rs
+++ b/crates/fp/montgomery/src/lib.rs
@@ -130,7 +130,7 @@ where
             f.len() < 2 * self.p.len(),
             "Reducer の次数( = p.len() ）の 2 倍未満でお願いします。"
         );
-        reduce(self.p.clone(), self.k.clone(), f)
+        reduce(self.p.clone(), self.k.clone(), &f)
     }
     /// 多項式 f を受け取って、MR⁻¹ ( f ) を計算します。
     ///
@@ -313,7 +313,7 @@ fn normalize<M: Mod>(f: &mut Vec<Fp<M>>) {
     }
 }
 
-fn reduce<M: Mod>(p: Vec<Fp<M>>, k: Vec<Fp<M>>, f: Vec<Fp<M>>) -> Vec<Fp<M>>
+fn reduce<M: Mod>(p: Vec<Fp<M>>, k: Vec<Fp<M>>, f: &[Fp<M>]) -> Vec<Fp<M>>
 where
     Fp<M>: Convolution,
 {
@@ -455,7 +455,7 @@ mod tests {
             let expected_to_be_f = mont.reduce_inverse(mont.reduce(f.clone()));
             assert_eq!(normal_f, expected_to_be_f);
 
-            let expected_to_be_f = mont.reduce(mont.reduce_inverse(f.clone()));
+            let expected_to_be_f = mont.reduce(mont.reduce_inverse(f));
             assert_eq!(normal_f, expected_to_be_f);
         }
     }

--- a/crates/fp/montgomery/src/lib.rs
+++ b/crates/fp/montgomery/src/lib.rs
@@ -399,7 +399,7 @@ mod tests {
     }
 
     #[test_case(3, 50; "small")]
-    #[test_case(30, 100000; "medium")]
+    #[test_case(30, 100_000; "medium")]
     #[test_case(std::u32::MAX, std::u64::MAX; "large")]
     fn test_pow_single(lim: u32, pow_lim: u64) {
         let mut rng = StdRng::seed_from_u64(42);

--- a/crates/geometry/convex_hull/src/lib.rs
+++ b/crates/geometry/convex_hull/src/lib.rs
@@ -138,8 +138,8 @@ mod tests {
             let n = rng.gen_range(0..vertex_number);
             let a = iter::repeat_with(|| {
                 [
-                    rng.gen_range(-coord_max..coord_max + 1),
-                    rng.gen_range(-coord_max..coord_max + 1),
+                    rng.gen_range(-coord_max..=coord_max),
+                    rng.gen_range(-coord_max..=coord_max),
                 ]
             })
             .take(n)
@@ -174,8 +174,8 @@ mod tests {
             let n = rng.gen_range(1..vertex_number);
             let a = iter::repeat_with(|| {
                 [
-                    rng.gen_range(-coord_max..coord_max + 1),
-                    rng.gen_range(-coord_max..coord_max + 1),
+                    rng.gen_range(-coord_max..=coord_max),
+                    rng.gen_range(-coord_max..=coord_max),
                 ]
             })
             .take(n)

--- a/crates/geometry/convex_hull/src/lib.rs
+++ b/crates/geometry/convex_hull/src/lib.rs
@@ -71,7 +71,7 @@ pub fn convex_hull(a: &[[i64; 2]]) -> Vec<[i64; 2]> {
 #[allow(clippy::many_single_char_names)]
 pub fn caliper(a: &[[i64; 2]]) -> (i64, [[i64; 2]; 2]) {
     assert!(!a.is_empty());
-    let a = convex_hull(&a);
+    let a = convex_hull(a);
     if a.len() == 1 {
         (0, [a[0], a[0]])
     } else if a.len() == 2 {

--- a/crates/geometry/convex_hull/src/lib.rs
+++ b/crates/geometry/convex_hull/src/lib.rs
@@ -190,9 +190,7 @@ mod tests {
 
         fn brute(a: &[[i64; 2]]) -> i64 {
             a.iter()
-                .copied()
-                .map(|p| a.iter().copied().map(move |q| [p, q]))
-                .flatten()
+                .copied().flat_map(|p| a.iter().copied().map(move |q| [p, q]))
                 .map(|[p, q]| sqmag(p, q))
                 .max()
                 .unwrap()

--- a/crates/geometry/convex_hull/src/lib.rs
+++ b/crates/geometry/convex_hull/src/lib.rs
@@ -169,6 +169,14 @@ mod tests {
 
     #[allow(clippy::many_single_char_names)]
     fn test_caliper_base(coord_max: i64, vertex_number: usize, iteration: u32) {
+        fn brute(a: &[[i64; 2]]) -> i64 {
+            a.iter()
+                .copied()
+                .flat_map(|p| a.iter().copied().map(move |q| [p, q]))
+                .map(|[p, q]| sqmag(p, q))
+                .max()
+                .unwrap()
+        }
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..iteration {
             let n = rng.gen_range(1..vertex_number);
@@ -186,14 +194,6 @@ mod tests {
             let (d, [p, q]) = caliper(&a);
             assert_eq!(d, sqmag(p, q));
             assert_eq!(d, brute(&a));
-        }
-
-        fn brute(a: &[[i64; 2]]) -> i64 {
-            a.iter()
-                .copied().flat_map(|p| a.iter().copied().map(move |q| [p, q]))
-                .map(|[p, q]| sqmag(p, q))
-                .max()
-                .unwrap()
         }
     }
 }

--- a/crates/heaps/skew-heap/src/lib.rs
+++ b/crates/heaps/skew-heap/src/lib.rs
@@ -70,7 +70,7 @@ impl<A: Ord> Extend<A> for SkewHeap<A> {
 }
 impl<A: Ord> FromIterator<A> for SkewHeap<A> {
     fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
-        let mut heap = SkewHeap::new();
+        let mut heap = Self::new();
         heap.extend(iter);
         heap
     }

--- a/crates/heaps/skew-heap/src/lib.rs
+++ b/crates/heaps/skew-heap/src/lib.rs
@@ -226,8 +226,8 @@ mod tests {
                         // collect
                         let mut expected = binary.iter().copied().collect_vec();
                         let mut result = skew.clone().into_sorted_vec();
-                        expected.sort();
-                        result.sort();
+                        expected.sort_unstable();
+                        result.sort_unstable();
                         assert_eq!(expected, result);
                     }
                     _ => unreachable!(),

--- a/crates/math/newton/src/lib.rs
+++ b/crates/math/newton/src/lib.rs
@@ -37,10 +37,10 @@ mod tests {
 
     #[test]
     fn test_sqrt() {
-        let mut rng = StdRng::seed_from_u64(42);
         fn square(x: u64) -> u64 {
             x * x
         }
+        let mut rng = StdRng::seed_from_u64(42);
         for y in 0..100 {
             let x = sqrt(y);
             assert!(square(x) <= y);
@@ -76,10 +76,10 @@ mod tests {
 
     #[test]
     fn test_triangular_root() {
-        let mut rng = StdRng::seed_from_u64(42);
         fn triangular(x: u64) -> u64 {
             x * (x + 1) / 2
         }
+        let mut rng = StdRng::seed_from_u64(42);
         for y in 0..100 {
             let x = triangular_root(y);
             assert!(triangular(x) <= y);

--- a/crates/range-query/lazy_segbeats/src/lib.rs
+++ b/crates/range-query/lazy_segbeats/src/lib.rs
@@ -226,7 +226,7 @@ struct Node<T> {
 }
 impl<T: Elm> Node<T> {
     fn new() -> Self {
-        Node {
+        Self {
             max: [T::min_value(), T::min_value()],
             c_max: 0,
             min: [T::max_value(), T::max_value()],
@@ -237,7 +237,7 @@ impl<T: Elm> Node<T> {
         }
     }
     fn single(x: T) -> Self {
-        Node {
+        Self {
             max: [x, T::min_value()],
             c_max: 1,
             min: [x, T::max_value()],
@@ -279,7 +279,7 @@ impl<T: Elm> Node<T> {
         }
         self.min[0] = x;
     }
-    fn merge(left: Node<T>, right: Node<T>) -> Self {
+    fn merge(left: Self, right: Self) -> Self {
         use std::cmp::Ordering;
         let (max, c_max) = {
             let [a, b] = left.max;

--- a/crates/range-query/lazy_segtree/src/lib.rs
+++ b/crates/range-query/lazy_segtree/src/lib.rs
@@ -250,7 +250,7 @@ mod tests {
             apply: std::ops::Add::add,
             compose: std::ops::Add::add,
             identity: || std::u32::MAX,
-            id_action: || 0u32,
+            id_action: || 0_u32,
         }
         .finish();
         assert_eq!(seg.get(0), 0);
@@ -265,7 +265,7 @@ mod tests {
             apply: std::ops::Add::add,
             compose: std::ops::Add::add,
             identity: || std::u32::MAX,
-            id_action: || 0u32,
+            id_action: || 0_u32,
         }
         .finish();
         seg.modify(0, |x| *x = 10);
@@ -281,7 +281,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..20 {
             let n = rng.gen_range(1..40);
-            let mut a = iter::repeat_with(|| rng.gen_range(0u32..30))
+            let mut a = iter::repeat_with(|| rng.gen_range(0_u32..30))
                 .take(n)
                 .collect::<Vec<_>>()
                 .into_boxed_slice();
@@ -291,7 +291,7 @@ mod tests {
                 apply: std::ops::Add::add,
                 compose: std::ops::Add::add,
                 identity: || std::u32::MAX,
-                id_action: || 0u32,
+                id_action: || 0_u32,
             }
             .finish();
             println!("a = {:?}", &a);
@@ -339,7 +339,7 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..200 {
             let n = rng.gen_range(1..40);
-            let mut a = iter::repeat_with(|| rng.gen_range(0u32..30))
+            let mut a = iter::repeat_with(|| rng.gen_range(0_u32..30))
                 .take(n)
                 .collect::<Vec<_>>()
                 .into_boxed_slice();
@@ -349,7 +349,7 @@ mod tests {
                 apply: std::ops::Add::add,
                 compose: std::ops::Add::add,
                 identity: || std::u32::MAX,
-                id_action: || 0u32,
+                id_action: || 0_u32,
             }
             .finish();
             println!("a = {:?}", &a);

--- a/crates/range-query/segbeats/src/lib.rs
+++ b/crates/range-query/segbeats/src/lib.rs
@@ -203,7 +203,7 @@ struct Node<T> {
 }
 impl<T: Elm> Node<T> {
     fn new() -> Self {
-        Node {
+        Self {
             max: [T::min_value(), T::min_value()],
             c_max: 0,
             min: [T::max_value(), T::max_value()],
@@ -212,7 +212,7 @@ impl<T: Elm> Node<T> {
         }
     }
     fn single(x: T) -> Self {
-        Node {
+        Self {
             max: [x, T::min_value()],
             c_max: 1,
             min: [x, T::max_value()],
@@ -240,7 +240,7 @@ impl<T: Elm> Node<T> {
         }
         self.min[0] = x;
     }
-    fn merge(left: Node<T>, right: Node<T>) -> Self {
+    fn merge(left: Self, right: Self) -> Self {
         use std::cmp::Ordering;
         let (max, c_max) = {
             let [a, b] = left.max;

--- a/crates/range-query/segbeats_task3/src/lib.rs
+++ b/crates/range-query/segbeats_task3/src/lib.rs
@@ -283,7 +283,7 @@ struct Node<T> {
 }
 impl<T: Elm> Node<T> {
     fn new() -> Self {
-        Node {
+        Self {
             max: [T::min_value(); 2],
             c_max: 0,
             min: [T::max_value(); 2],
@@ -298,7 +298,7 @@ impl<T: Elm> Node<T> {
         }
     }
     fn single(x: T) -> Self {
-        Node {
+        Self {
             max: [x, T::min_value()],
             c_max: 1,
             min: [x, T::max_value()],
@@ -360,7 +360,7 @@ impl<T: Elm> Node<T> {
         self.change_count += self.c_min as u64 * weight as u64;
         self.lazy_change_min_count += weight; // weigt には和が渡ってきますから、片方に寄せておくと良いです。
     }
-    fn merge(node: &mut Node<T>, left: Node<T>, right: Node<T>) {
+    fn merge(node: &mut Self, left: Self, right: Self) {
         assert_eq!(node.lazy_change_min_count, 0);
         assert_eq!(node.lazy_change_max_count, 0);
         assert_eq!(node.lazy_add_count, 0);

--- a/crates/range-query/segbeats_task3/src/lib.rs
+++ b/crates/range-query/segbeats_task3/src/lib.rs
@@ -316,7 +316,7 @@ impl<T: Elm> Node<T> {
         assert!(self.max[1] < x && x < self.max[0]);
         self.sum += (x - self.max[0]).mul_u32(self.c_max);
         let orig_max = replace(&mut self.max[0], x);
-        self.change_count += self.c_max as u64 * weight as u64;
+        self.change_count += u64::from(self.c_max) * u64::from(weight);
         if orig_max == self.min[0] {
             self.min[0] = x;
         }
@@ -329,7 +329,7 @@ impl<T: Elm> Node<T> {
         assert!(self.min[0] < x && x < self.min[1]);
         self.sum += (x - self.min[0]).mul_u32(self.c_min);
         let orig_min = replace(&mut self.min[0], x);
-        self.change_count += self.c_min as u64 * weight as u64;
+        self.change_count += u64::from(self.c_min) * u64::from(weight);
         if orig_min == self.max[0] {
             self.max[0] = x;
         }
@@ -348,7 +348,7 @@ impl<T: Elm> Node<T> {
             .filter(|y| **y != T::max_value())
             .for_each(|y| *y += x);
         self.sum += x.mul_u32(self.len);
-        self.change_count += self.len as u64 * weight as u64;
+        self.change_count += u64::from(self.len) * u64::from(weight);
         self.lazy_add += x;
         self.lazy_add_count += weight;
     }
@@ -357,7 +357,7 @@ impl<T: Elm> Node<T> {
         self.min[0] = x;
         self.max[0] = x;
         self.sum = x.mul_u32(self.len);
-        self.change_count += self.c_min as u64 * weight as u64;
+        self.change_count += u64::from(self.c_min) * u64::from(weight);
         self.lazy_change_min_count += weight; // weigt には和が渡ってきますから、片方に寄せておくと良いです。
     }
     fn merge(node: &mut Self, left: Self, right: Self) {

--- a/crates/range-query/segbeats_task3/src/lib.rs
+++ b/crates/range-query/segbeats_task3/src/lib.rs
@@ -361,11 +361,11 @@ impl<T: Elm> Node<T> {
         self.lazy_change_min_count += weight; // weigt には和が渡ってきますから、片方に寄せておくと良いです。
     }
     fn merge(node: &mut Self, left: Self, right: Self) {
+        use std::cmp::Ordering;
         assert_eq!(node.lazy_change_min_count, 0);
         assert_eq!(node.lazy_change_max_count, 0);
         assert_eq!(node.lazy_add_count, 0);
         assert_eq!(node.lazy_add, T::zero());
-        use std::cmp::Ordering;
         let (max, c_max) = {
             let [a, b] = left.max;
             let [c, d] = right.max;

--- a/crates/range-query/segtree/src/lib.rs
+++ b/crates/range-query/segtree/src/lib.rs
@@ -300,6 +300,10 @@ mod tests {
 
     #[test]
     fn test_strcat() {
+        #[allow(clippy::needless_pass_by_value)]
+        fn strcat(s: String, t: String) -> String {
+            s.chars().chain(t.chars()).collect::<String>()
+        }
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..20 {
             let n = rng.gen_range(1..40);
@@ -346,10 +350,6 @@ mod tests {
                     _ => panic!(),
                 }
             }
-        }
-        #[allow(clippy::needless_pass_by_value)]
-        fn strcat(s: String, t: String) -> String {
-            s.chars().chain(t.chars()).collect::<String>()
         }
     }
 }

--- a/crates/range-query/segtree/src/lib.rs
+++ b/crates/range-query/segtree/src/lib.rs
@@ -347,6 +347,7 @@ mod tests {
                 }
             }
         }
+        #[allow(clippy::needless_pass_by_value)]
         fn strcat(s: String, t: String) -> String {
             s.chars().chain(t.chars()).collect::<String>()
         }

--- a/crates/range-query/sparse_table/src/lib.rs
+++ b/crates/range-query/sparse_table/src/lib.rs
@@ -78,7 +78,7 @@ fn convert_to_range<T>(len: usize, range_bound: T) -> ops::Range<usize>
 where
     T: ops::RangeBounds<usize>,
 {
-    use ops::Bound::*;
+    use ops::Bound::{Excluded, Included, Unbounded};
     ops::Range {
         start: match range_bound.start_bound() {
             Excluded(&x) => x + 1,

--- a/crates/range-query/swag/src/lib.rs
+++ b/crates/range-query/swag/src/lib.rs
@@ -264,7 +264,7 @@ mod tests {
     #[test]
     fn test_algo_hand() {
         let mut swag = Swag::new((0..10).map(|i| (i, 1)).collect_vec(), |(x, d), (y, e)| {
-            (10u32.pow(e) * x + y, d + e)
+            (10_u32.pow(e) * x + y, d + e)
         });
         assert_eq!(swag.fold(1..3), Some((12, 2)));
         assert_eq!(swag.fold(4..4), None);

--- a/crates/range-query/swag/src/lib.rs
+++ b/crates/range-query/swag/src/lib.rs
@@ -210,11 +210,7 @@ where
             .iter()
             .chain(self.v.borrow()[self.end..end].iter())
             .copied();
-        self.accum = if let Some(first) = iter.next() {
-            Some(iter.fold(first, &self.folder))
-        } else {
-            None
-        };
+        self.accum = iter.next().map(|first| iter.fold(first, &self.folder));
         self.end = end;
     }
 }

--- a/crates/string/trie/src/trie_map.rs
+++ b/crates/string/trie/src/trie_map.rs
@@ -71,11 +71,9 @@ impl<V> TrieMap<V> {
     pub fn insert(&mut self, key: impl IntoIterator<Item = usize>, value: V) -> Option<V> {
         let mut key = key.into_iter();
         let me = self.0.get_or_insert_with(|| Box::new(Node::new()));
-        let next = key.next();
-        if let Some(next) = next {
-            me.child[next].insert(key, value)
-        } else {
-            me.value.replace(value)
+        match key.next() {
+            Some(next) => me.child[next].insert(key, value),
+            None => me.value.replace(value),
         }
     }
 
@@ -98,13 +96,11 @@ impl<V> TrieMap<V> {
     pub fn remove(&mut self, key: impl IntoIterator<Item = usize>) -> Option<V> {
         let mut key = key.into_iter();
         let me = self.0.as_deref_mut()?;
-        let next = key.next();
-        if let Some(next) = next {
-            me.child[next].remove(key)
-        } else {
+        match key.next() {
+            Some(next) => me.child[next].remove(key),
             // TODO:
             // 不要になったノードを削除したいです。しかし、サイズを管理しておかないと実現できません。
-            me.value.take()
+            None => me.value.take(),
         }
     }
 
@@ -126,11 +122,9 @@ impl<V> TrieMap<V> {
     pub fn get(&self, key: impl IntoIterator<Item = usize>) -> Option<&V> {
         let mut key = key.into_iter();
         let me = self.0.as_deref()?;
-        let next = key.next();
-        if let Some(next) = next {
-            me.child[next].get(key)
-        } else {
-            me.value.as_ref()
+        match key.next() {
+            Some(next) => me.child[next].get(key),
+            None => me.value.as_ref(),
         }
     }
 
@@ -155,11 +149,9 @@ impl<V> TrieMap<V> {
     pub fn get_mut(&mut self, key: impl IntoIterator<Item = usize>) -> Option<&mut V> {
         let mut key = key.into_iter();
         let me = self.0.as_deref_mut()?;
-        let next = key.next();
-        if let Some(next) = next {
-            me.child[next].get_mut(key)
-        } else {
-            me.value.as_mut()
+        match key.next() {
+            Some(next) => me.child[next].get_mut(key),
+            None => me.value.as_mut(),
         }
     }
 
@@ -187,11 +179,9 @@ impl<V> TrieMap<V> {
     pub fn get_or_insert(&mut self, key: impl IntoIterator<Item = usize>, value: V) -> &mut V {
         let mut key = key.into_iter();
         let me = self.0.get_or_insert_with(|| Box::new(Node::new()));
-        let next = key.next();
-        if let Some(next) = next {
-            me.child[next].get_or_insert(key, value)
-        } else {
-            me.value.get_or_insert(value)
+        match key.next() {
+            Some(next) => me.child[next].get_or_insert(key, value),
+            None => me.value.get_or_insert(value),
         }
     }
 
@@ -223,11 +213,9 @@ impl<V> TrieMap<V> {
     ) -> &mut V {
         let mut key = key.into_iter();
         let me = self.0.get_or_insert_with(|| Box::new(Node::new()));
-        let next = key.next();
-        if let Some(next) = next {
-            me.child[next].get_or_insert_with(key, f)
-        } else {
-            me.value.get_or_insert_with(f)
+        match key.next() {
+            Some(next) => me.child[next].get_or_insert_with(key, f),
+            None => me.value.get_or_insert_with(f),
         }
     }
 

--- a/crates/string/trie/src/trie_map.rs
+++ b/crates/string/trie/src/trie_map.rs
@@ -269,7 +269,7 @@ impl<V> TrieMap<V> {
     pub fn for_each_prefix(
         &self,
         key: impl IntoIterator<Item = usize>,
-        mut visit: impl FnMut(&TrieMap<V>),
+        mut visit: impl FnMut(&Self),
     ) {
         let mut key = key.into_iter();
         if let Some(me) = self.0.as_deref() {

--- a/crates/utils/grid/src/coord.rs
+++ b/crates/utils/grid/src/coord.rs
@@ -11,7 +11,7 @@ pub struct Coord {
 }
 #[allow(clippy::many_single_char_names)]
 pub fn coord(h: usize, w: usize, d: Dihedral) -> Coord {
-    use Dihedral::*;
+    use Dihedral::{R0, R0S, R1, R1S, R2, R2S, R3, R3S};
     let mut h = h as isize;
     let mut w = w as isize;
     let (origin, x, y) = match d {

--- a/crates/utils/grid/src/coord.rs
+++ b/crates/utils/grid/src/coord.rs
@@ -1,6 +1,7 @@
 use super::{swap_size, Dihedral};
 use std::mem::swap;
 
+#[derive(Clone, Debug, Default, Hash, PartialEq, Copy)]
 pub struct Coord {
     pub origin: isize,
     pub x: isize,

--- a/crates/utils/grid/src/dihedral.rs
+++ b/crates/utils/grid/src/dihedral.rs
@@ -51,7 +51,7 @@ impl TryFrom<u8> for Dihedral {
 }
 impl From<Dihedral> for u8 {
     fn from(src: Dihedral) -> Self {
-        use Dihedral::*;
+        use Dihedral::{R0, R0S, R1, R1S, R2, R2S, R3, R3S};
         match src {
             R0 => 0,
             R1 => 1,

--- a/crates/utils/grid/src/lib.rs
+++ b/crates/utils/grid/src/lib.rs
@@ -10,6 +10,6 @@ pub use iter::{Row, RowIter, Rows};
 use coord::{coord, Coord};
 
 fn swap_size(d: Dihedral) -> bool {
-    use Dihedral::*;
+    use Dihedral::{R0S, R1, R2S, R3};
     matches!(d, R1 | R3 | R0S | R2S)
 }

--- a/crates/utils/gridtools/src/lib.rs
+++ b/crates/utils/gridtools/src/lib.rs
@@ -64,7 +64,7 @@ pub fn exact_size_of_grid<T>(table: &[Vec<T>]) -> (usize, usize) {
 /// assert_eq!(transpose(&a), b);
 /// ```
 pub fn transpose<T: Clone>(table: &[Vec<T>]) -> Vec<Vec<T>> {
-    let (h, w) = exact_size_of_grid(&table);
+    let (h, w) = exact_size_of_grid(table);
     (0..w)
         .map(|j| (0..h).map(|i| table[i][j].clone()).collect::<Vec<_>>())
         .collect::<Vec<_>>()
@@ -80,7 +80,7 @@ pub fn transpose<T: Clone>(table: &[Vec<T>]) -> Vec<Vec<T>> {
 /// assert_eq!(anti_transpose(&a), b);
 /// ```
 pub fn anti_transpose<T: Clone>(table: &[Vec<T>]) -> Vec<Vec<T>> {
-    let (h, w) = exact_size_of_grid(&table);
+    let (h, w) = exact_size_of_grid(table);
     (0..w)
         .rev()
         .map(|j| {
@@ -131,7 +131,7 @@ pub fn reflect_horizontally<T: Clone>(table: &[Vec<T>]) -> Vec<Vec<T>> {
 /// assert_eq!(rotate_left(&a), b);
 /// ```
 pub fn rotate_right<T: Clone>(table: &[Vec<T>]) -> Vec<Vec<T>> {
-    let (h, w) = exact_size_of_grid(&table);
+    let (h, w) = exact_size_of_grid(table);
     (0..w)
         .map(|j| {
             (0..h)
@@ -152,7 +152,7 @@ pub fn rotate_right<T: Clone>(table: &[Vec<T>]) -> Vec<Vec<T>> {
 /// assert_eq!(rotate_right(&a), b);
 /// ```
 pub fn rotate_left<T: Clone>(table: &[Vec<T>]) -> Vec<Vec<T>> {
-    let (h, w) = exact_size_of_grid(&table);
+    let (h, w) = exact_size_of_grid(table);
     (0..w)
         .rev()
         .map(|j| (0..h).map(|i| table[i][j].clone()).collect::<Vec<_>>())

--- a/crates/utils/next_permutation/src/lib.rs
+++ b/crates/utils/next_permutation/src/lib.rs
@@ -7,18 +7,20 @@ pub fn next_permutation<T: Ord>(a: &mut [T]) -> bool {
 pub fn next_permutation_by<T>(a: &mut [T], mut cmp: impl FnMut(&T, &T) -> Ordering) -> bool {
     if a.is_empty() {
         true
-    } else if let Some(i) = (0..a.len() - 1).rfind(|&i| cmp(&a[i], &a[i + 1]) == Ordering::Less) {
-        a[i + 1..].reverse();
-        let j = i
-            + 1
-            + a[i + 1..]
-                .iter()
-                .position(|x| cmp(&a[i], x) == (Ordering::Less))
-                .unwrap();
-        a.swap(i, j);
-        true
     } else {
-        false
+        (0..a.len() - 1)
+            .rfind(|&i| cmp(&a[i], &a[i + 1]) == Ordering::Less)
+            .map_or(false, |i| {
+                a[i + 1..].reverse();
+                let j = i
+                    + 1
+                    + a[i + 1..]
+                        .iter()
+                        .position(|x| cmp(&a[i], x) == (Ordering::Less))
+                        .unwrap();
+                a.swap(i, j);
+                true
+            })
     }
 }
 

--- a/crates/utils/ngtio/src/i.rs
+++ b/crates/utils/ngtio/src/i.rs
@@ -173,12 +173,12 @@ mod token {
     impl<T> Token for T
     where
         T: str::FromStr,
-        <T as str::FromStr>::Err: fmt::Debug,
+        <Self as str::FromStr>::Err: fmt::Debug,
     {
-        type Output = T;
+        type Output = Self;
         fn parse(s: &str) -> Self::Output {
             s.parse()
-                .unwrap_or_else(|_| panic!("Parse error!: ({}: {})", s, any::type_name::<T>(),))
+                .unwrap_or_else(|_| panic!("Parse error!: ({}: {})", s, any::type_name::<Self>(),))
         }
     }
 

--- a/crates/utils/ngtio/src/i.rs
+++ b/crates/utils/ngtio/src/i.rs
@@ -405,7 +405,7 @@ GHI
         let mut s = make_buf("0 1 2 3 4 5 6 7 8 9\n");
         assert_eq!(s.tuple::<(u8, char)>(), (0, '1'));
         assert_eq!(s.tuple::<(u8,)>(), (2,));
-        let _: () = s.tuple::<()>();
+        s.tuple::<()>();
         assert_eq!(
             s.tuple::<(u8, u8, u8, u8, u8, u8, u8,)>(),
             (3, 4, 5, 6, 7, 8, 9)

--- a/crates/utils/not_nan/src/lib.rs
+++ b/crates/utils/not_nan/src/lib.rs
@@ -16,7 +16,7 @@ impl<T: Float> NotNaN<T> {
     pub fn from_float(value: T) -> Self {
         match value {
             ref value if value.float_is_nan() => panic!("これはなんですか？"),
-            value => NotNaN(value),
+            value => Self(value),
         }
     }
 
@@ -26,15 +26,15 @@ impl<T: Float> NotNaN<T> {
 }
 impl<T: Float> Eq for NotNaN<T> {}
 impl<T: Float> Ord for NotNaN<T> {
-    fn cmp(&self, other: &NotNaN<T>) -> Ordering {
-        match self.partial_cmp(&other) {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.partial_cmp(other) {
             Some(ord) => ord,
             None => unreachable!(),
         }
     }
 }
 impl<T: Float> PartialOrd for NotNaN<T> {
-    fn partial_cmp(&self, other: &NotNaN<T>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/crates/utils/open/src/lib.rs
+++ b/crates/utils/open/src/lib.rs
@@ -1,7 +1,7 @@
 use std::ops::{Bound, Range, RangeBounds};
 
 pub fn open(len: usize, range: impl RangeBounds<usize>) -> Range<usize> {
-    use Bound::*;
+    use Bound::{Excluded, Included, Unbounded};
     (match range.start_bound() {
         Unbounded => 0,
         Included(&x) => x,

--- a/crates/utils/prefix_sum/src/lib.rs
+++ b/crates/utils/prefix_sum/src/lib.rs
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_hand() {
-        let mut a = PrefixSum::with_zero(0u32);
+        let mut a = PrefixSum::with_zero(0_u32);
         a.push(1);
         assert_eq!(a.get(0), 1);
         assert_eq!(a.range(..), vec![1]);

--- a/crates/utils/randtools/src/lib.rs
+++ b/crates/utils/randtools/src/lib.rs
@@ -36,7 +36,7 @@ impl Distribution<Range<usize>> for SubRange {
         let Range { start, end } = self.0;
         assert!(start <= end);
         let mut l = rng.gen_range(start..end + 2);
-        let mut r = rng.gen_range(start..end + 1);
+        let mut r = rng.gen_range(start..=end);
         if l > r {
             mem::swap(&mut l, &mut r);
             r -= 1;
@@ -52,7 +52,7 @@ impl Distribution<Range<usize>> for NonEmptySubRange {
         let Range { start, end } = self.0;
         assert!(start < end);
         let mut l = rng.gen_range(start..end);
-        let mut r = rng.gen_range(start..end + 1);
+        let mut r = rng.gen_range(start..=end);
         if l >= r {
             mem::swap(&mut l, &mut r);
             r += 1;

--- a/crates/utils/randtools/src/tests/algo.rs
+++ b/crates/utils/randtools/src/tests/algo.rs
@@ -3,7 +3,7 @@ use std::mem;
 pub fn is_tree(g: &[Vec<usize>]) -> bool {
     // 頂点数 n, 辺数 2n - 2, 頂点番号 < n
     let n = g.len();
-    if g.iter().map(|v| v.len()).sum::<usize>() != 2 * n - 2 || g.iter().flatten().any(|&x| n <= x)
+    if g.iter().map(std::vec::Vec::len).sum::<usize>() != 2 * n - 2 || g.iter().flatten().any(|&x| n <= x)
     {
         return false;
     }

--- a/crates/utils/reverse/src/lib.rs
+++ b/crates/utils/reverse/src/lib.rs
@@ -9,7 +9,7 @@ pub struct Reverse<T>(pub T);
 
 impl<T: PartialOrd> PartialOrd for Reverse<T> {
     #[inline]
-    fn partial_cmp(&self, other: &Reverse<T>) -> Option<Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         other.0.partial_cmp(&self.0)
     }
 
@@ -33,7 +33,7 @@ impl<T: PartialOrd> PartialOrd for Reverse<T> {
 
 impl<T: Ord> Ord for Reverse<T> {
     #[inline]
-    fn cmp(&self, other: &Reverse<T>) -> Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         other.0.cmp(&self.0)
     }
 }

--- a/crates/utils/seq/src/lib.rs
+++ b/crates/utils/seq/src/lib.rs
@@ -286,7 +286,7 @@ mod repeat_with {
 }
 
 mod accumulate {
-    use super::*;
+    use super::{ops, size_hint};
 
     #[derive(Debug, Clone)]
     pub struct Accumulate<I, T> {

--- a/crates/utils/seq/src/lib.rs
+++ b/crates/utils/seq/src/lib.rs
@@ -203,9 +203,8 @@ mod step {
 
     pub fn step<T, U>(init: T, step: U) -> Step<T, U>
     where
-        T: Copy,
+        T: Copy + ::std::ops::Add<U, Output = T>,
         U: Copy,
-        T: ::std::ops::Add<U, Output = T>,
     {
         Step { now: init, step }
     }
@@ -218,9 +217,8 @@ mod step {
 
     impl<T, U> Iterator for Step<T, U>
     where
-        T: Copy,
+        T: Copy + ::std::ops::Add<U, Output = T>,
         U: Copy,
-        T: ::std::ops::Add<U, Output = T>,
     {
         type Item = T;
 
@@ -235,9 +233,8 @@ mod mul_step {
 
     pub fn mul_step<T, U>(init: T, step: U) -> MulStep<T, U>
     where
-        T: Copy,
+        T: Copy + ::std::ops::Mul<U, Output = T>,
         U: Copy,
-        T: ::std::ops::Mul<U, Output = T>,
     {
         MulStep { now: init, step }
     }
@@ -250,9 +247,8 @@ mod mul_step {
 
     impl<T, U> Iterator for MulStep<T, U>
     where
-        T: Copy,
+        T: Copy + ::std::ops::Mul<U, Output = T>,
         U: Copy,
-        T: ::std::ops::Mul<U, Output = T>,
     {
         type Item = T;
 

--- a/crates/utils/seq/src/lib.rs
+++ b/crates/utils/seq/src/lib.rs
@@ -121,13 +121,12 @@ mod adjacent {
         I: Iterator<Item = T>,
         T: Clone,
     {
-        if let Some(first) = iter.next() {
-            Adjacent {
+        match iter.next() {
+            Some(first) => Adjacent {
                 iter,
                 prv: Some(first),
-            }
-        } else {
-            Adjacent { iter, prv: None }
+            },
+            None => Adjacent { iter, prv: None },
         }
     }
 

--- a/crates/utils/seq/src/lib.rs
+++ b/crates/utils/seq/src/lib.rs
@@ -384,10 +384,7 @@ mod cartesian_product {
                 }
                 Some(x) => x,
             };
-            match self.a_cur {
-                None => None,
-                Some(ref a) => Some((a.clone(), elt_b)),
-            }
+            self.a_cur.as_ref().map(|a| (a.clone(), elt_b))
         }
 
         fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
## lint 基準

これが通ることを確認しました。今後これらも一部頑張るかもしれません。

ところでこれ設定ファイルにかけそうですね調べていませんが（あの？）

```bash
cargo +nightly clippy --all-targets -- \
    -W clippy::pedantic \
    -W clippy::nursery \
    -A clippy::must_use_candidate \
    -A clippy::non_ascii_literal \
    -A clippy::cast_sign_loss \
    -A clippy::cast_possible_wrap \
    -A clippy::cast_possible_truncation \
    -A clippy::cast_precision_loss \
    -A clippy::doc_markdown \
    -A clippy::missing_panics_doc \
    -A clippy::module_name_repetitions \
    -A clippy::shadow_unrelated \
    -A clippy::maybe_infinite_iter \
    -A clippy::similar_names \
    -A clippy::filter_map \
    -A clippy::missing_const_for_fn
```

## 今後頑張るかもしれないもの

* `missing_const_for_fn`
* `similar_names`


## CI の変更

CI にも stable の同名の lint を適用します。ただし…？

次のものは存在しないオプションと言われてしまいましたので、除きました。

* `-A cliippy::missing_panics_doc`

次のものは CI でだけ落ちてしまったので追加しました。（前から思っているのですが、CI と何が違うのでしょうね……）

* `-A clippy::flat_map`
* `-A clippy::use_self`

`use_self` は頑張っても良いかもですね。

次のものは CI で警告が出ています。あとでがんばるつもりです。（）

* `clippy:::empty_enum`