### PR TITLE
feature/use rust 1.42.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-      toolchain: 1.42
     - name: Build
       run: cargo build --release
 
@@ -23,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-      toolchain: 1.42
     - name: Clippy
       run: |
         cargo clippy --all-targets -- \
@@ -50,8 +46,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-      toolchain: 1.42
     - name: Run tests
       run: cargo test
 
@@ -59,7 +53,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-      toolchain: 1.42
     - name: Run cargo-doc
       run: cargo doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,16 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+      toolchain: 1.42
     - name: Build
-      run: cargo +1.42.0 build --release
+      run: cargo build --release
 
   clippy:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+      toolchain: 1.42
     - name: Clippy
       run: |
-        cargo +1.42.0 clippy --all-targets -- \
+        cargo clippy --all-targets -- \
         -W clippy::pedantic \
         -W clippy::nursery \
         -A clippy::must_use_candidate \
@@ -46,12 +50,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+      toolchain: 1.42
     - name: Run tests
-      run: cargo +1.42.0 test
+      run: cargo test
 
   doc:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run cargo +1.42.0-doc
-      run: cargo +1.42.0 doc
+      with:
+      toolchain: 1.42
+    - name: Run cargo-doc
+      run: cargo doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --release
+      run: cargo +1.42.0 build --release
 
   clippy:
     runs-on: ubuntu-latest
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Clippy
       run: |
-        cargo clippy --all-targets -- \
+        cargo +1.42.0 clippy --all-targets -- \
         -W clippy::pedantic \
         -W clippy::nursery \
         -A clippy::must_use_candidate \
@@ -47,11 +47,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run tests
-      run: cargo test
+      run: cargo +1.42.0 test
 
   doc:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run cargo-doc
-      run: cargo doc
+    - name: Run cargo +1.42.0-doc
+      run: cargo +1.42.0 doc

--- a/crates/bfs/src/lib.rs
+++ b/crates/bfs/src/lib.rs
@@ -131,7 +131,8 @@ mod tests {
         assert_eq!(dist[start], 0);
         for (u, v) in g
             .iter()
-            .enumerate().flat_map(|(i, v)| v.iter().map(move |&j| (i, j)))
+            .enumerate()
+            .flat_map(|(i, v)| v.iter().map(move |&j| (i, j)))
         {
             assert!(dist[u] == dist[v] || dist[u] + 1 == dist[v] || dist[u] == dist[v] + 1);
         }
@@ -171,7 +172,8 @@ mod tests {
             assert_eq!(path.len(), diam as usize + 1);
             let edges = g
                 .iter()
-                .enumerate().flat_map(|(i, v)| v.iter().map(move |&j| (i, j)))
+                .enumerate()
+                .flat_map(|(i, v)| v.iter().map(move |&j| (i, j)))
                 .collect::<HashSet<_>>();
             accum::for_each(&path, |&u, &v| assert!(edges.contains(&(u, v))));
         }
@@ -182,7 +184,8 @@ mod tests {
         let mut dist = vec![vec![std::u32::MAX; n]; n];
         (0..n).for_each(|i| dist[i][i] = 0);
         g.iter()
-            .enumerate().flat_map(|(i, v)| v.iter().copied().map(move |j| (i, j)))
+            .enumerate()
+            .flat_map(|(i, v)| v.iter().copied().map(move |j| (i, j)))
             .for_each(|(i, j)| {
                 dist[i][j] = 1;
                 dist[j][i] = 1
@@ -195,9 +198,10 @@ mod tests {
                 }
             }
         }
-        assert!(dist.iter().flatten().all(|&x| x != u32::MAX));
+        assert!(dist.iter().flatten().all(|&x| x != std::u32::MAX));
         dist.iter()
-            .enumerate().flat_map(|(i, v)| v.iter().copied().enumerate().map(move |(j, x)| (i, j, x)))
+            .enumerate()
+            .flat_map(|(i, v)| v.iter().copied().enumerate().map(move |(j, x)| (i, j, x)))
             .map(|(i, j, x)| ([i, j], x))
             .max_by_key(|&(_, x)| x)
             .unwrap()

--- a/crates/dual_segtree/src/lib.rs
+++ b/crates/dual_segtree/src/lib.rs
@@ -20,7 +20,7 @@
 //! }
 //!
 //! // 構築
-//! let mut seg = DualSegtree::<O>::new([[0, 0], [0, 0]]);
+//! let mut seg = DualSegtree::<O>::new(vec![[0, 0], [0, 0]]);
 //! assert_eq!(seg.collect_vec(), vec![[0, 0], [0, 0]]);
 //!
 //! // 更新

--- a/crates/fps/src/arith.rs
+++ b/crates/fps/src/arith.rs
@@ -258,11 +258,12 @@ mod tests {
             let expected_to_be_a = Fp::convolution(result.clone(), result.clone());
             assert_eq!(
                 &expected_to_be_a[..precision],
-                &a.iter()
+                a.iter()
                     .copied()
                     .chain(repeat(Fp::new(0)))
                     .take(precision)
                     .collect::<Vec<_>>()
+                    .as_slice(),
             );
         }
     }

--- a/crates/hld/src/lib.rs
+++ b/crates/hld/src/lib.rs
@@ -52,7 +52,7 @@
 //! ];
 //! let hld = Hld::new(root, &g);
 //!
-//! assert_eq!(hld.child(), vec![vec![2, 1], Vec::new(), vec![3], Vec::new()]);
+//! assert_eq!(hld.child(), &[vec![2, 1], Vec::new(), vec![3], Vec::new()]);
 //! assert_eq!(hld.time(), &[0, 3, 1, 2]);
 //! assert_eq!(hld.ord(), &[0, 2, 3, 1]);
 //! assert_eq!(hld.parent(), &[0, 0, 0, 2]);

--- a/crates/hungarian/src/lib.rs
+++ b/crates/hungarian/src/lib.rs
@@ -34,7 +34,8 @@ pub fn hungarian<T: Value>(cost_matrix: &[Vec<T>]) -> HungarianResult<T> {
     let mut left = vec![T::infinity(); h].into_boxed_slice();
     for (i, x) in cost_matrix
         .iter()
-        .enumerate().flat_map(|(i, v)| v.iter().map(move |&x| (i, x)))
+        .enumerate()
+        .flat_map(|(i, v)| v.iter().map(move |&x| (i, x)))
     {
         if x < all_min {
             all_min = x;
@@ -275,7 +276,8 @@ mod tests {
         // feasibility
         for (i, j, x) in cost_matrix
             .iter()
-            .enumerate().flat_map(|(i, v)| v.iter().enumerate().map(move |(j, &x)| (i, j, x)))
+            .enumerate()
+            .flat_map(|(i, v)| v.iter().enumerate().map(move |(j, &x)| (i, j, x)))
         {
             assert!(
                 right[j] <= x + left[i] + T::epsilon(),
@@ -332,7 +334,7 @@ mod tests {
             .sum::<T>()
     }
 
-    trait Epsilon: AbsDiffEq<Epsilon = Self> {
+    trait Epsilon: AbsDiffEq<Epsilon = Self> + Sized {
         fn epsilon() -> Self;
     }
     macro_rules! impl_epsilon_int {

--- a/crates/new_fp/src/algo.rs
+++ b/crates/new_fp/src/algo.rs
@@ -44,7 +44,7 @@ mod tests {
 
     #[test]
     fn test_ext_euclid_modinv() {
-        for p in SMALL_PRIMES {
+        for &p in SMALL_PRIMES.iter() {
             for x in 1..p {
                 let y = ext_euclid_modinv(x, p);
                 assert!((1..p).contains(&y));

--- a/crates/segtree/src/lib.rs
+++ b/crates/segtree/src/lib.rs
@@ -647,11 +647,11 @@ mod tests {
                 }
                 if l != 0 && l < r {
                     let range = (Bound::Excluded(l), Bound::Excluded(r));
-                    v.push((seg.fold(range), &a[range]));
+                    v.push((seg.fold(range), &a[l + 1..r]));
                 }
                 if l != 0 && l <= r && r < n {
                     let range = (Bound::Excluded(l), Bound::Included(r));
-                    v.push((seg.fold(range), &a[range]));
+                    v.push((seg.fold(range), &a[l + 1..=r]));
                 }
                 v
             })
@@ -664,7 +664,7 @@ mod tests {
                 }
                 if i != 0 && i != n {
                     let range = (Bound::Excluded(i), Bound::Unbounded);
-                    v.push((seg.fold(range), &a[range]));
+                    v.push((seg.fold(range), &a[i + 1..]));
                 }
                 v
             }))
@@ -690,7 +690,12 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..20 {
             let n = rng.gen_range(1..=10);
-            let mut a = ('a'..).take(n).map(|c| c.to_string()).collect::<Vec<_>>();
+            let mut a = (0..)
+                .take(n)
+                .map(|x| (x + b'a') as char)
+                .take(n)
+                .map(|c| c.to_string())
+                .collect::<Vec<_>>();
             let mut seg = Segtree::<O>::new(a.iter().cloned());
             for _ in 0..2 * n {
                 match rng.gen_range(0..2) {
@@ -732,7 +737,12 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..20 {
             let n = rng.gen_range(1..=10);
-            let a = ('a'..).take(n).map(|c| c.to_string()).collect::<Vec<_>>();
+            let a = (0..)
+                .take(n)
+                .map(|x| (x + b'a') as char)
+                .take(n)
+                .map(|c| c.to_string())
+                .collect::<Vec<_>>();
             let seg = Segtree::<O>::new(a.iter().cloned());
             for _ in 0..2 * n {
                 let mut l = rng.gen_range(0..n);
@@ -767,7 +777,11 @@ mod tests {
         let mut rng = StdRng::seed_from_u64(42);
         for _ in 0..20 {
             let n = rng.gen_range(1..=10);
-            let a = ('a'..).take(n).map(|c| c.to_string()).collect::<Vec<_>>();
+            let a = (0..)
+                .take(n)
+                .map(|x| (x + b'a') as char)
+                .map(|c| c.to_string())
+                .collect::<Vec<_>>();
             let seg = Segtree::<O>::new(a.iter().cloned());
             for _ in 0..2 * n {
                 let mut l = rng.gen_range(0..n);

--- a/crates/trie/src/trie_map.rs
+++ b/crates/trie/src/trie_map.rs
@@ -293,11 +293,9 @@ impl<V> TrieMap<V> {
     /// ].into_iter();
     /// map.for_each_kv(|k, &v| {
     ///     let (ek, ev) = expected.next().unwrap();
-    ///     assert_eq!(k, ek);
+    ///     assert_eq!(k, ek.as_slice());
     ///     assert_eq!(v, ev);
     /// });
-    ///
-    ///
     /// ```
     pub fn for_each_kv(&self, mut visit: impl FnMut(&[usize], &V)) {
         let mut prefix = Vec::new();

--- a/crates/trie/src/trie_set.rs
+++ b/crates/trie/src/trie_set.rs
@@ -179,7 +179,7 @@ impl TrieSet {
     /// ].into_iter();
     /// set.for_each(|k| {
     ///     let ek = expected.next().unwrap();
-    ///     assert_eq!(k, ek);
+    ///     assert_eq!(k, ek.as_slice());
     /// });
     /// ```
     pub fn for_each(&self, mut visit: impl FnMut(&[usize])) {


### PR DESCRIPTION
- Add `+1.42.0` option to ci cargo commands.
- Fix tests to compile with rust 1.42.0.
